### PR TITLE
Include filename in vp

### DIFF
--- a/R/bioRad.R
+++ b/R/bioRad.R
@@ -318,7 +318,7 @@ readvp = function(filename){
   }
 
   #prepare output
-  output=list(radar=radar,datetime=datetime,data=profile,attributes=list(how=attribs.how,what=attribs.what,where=attribs.where))
+  output=list(filename=filename,radar=radar,datetime=datetime,data=profile,attributes=list(how=attribs.how,what=attribs.what,where=attribs.where))
   class(output) = "vp"
   output
 }


### PR DESCRIPTION
It's sometimes useful to know from which file a vp object was generated, so this pull request adds the attribute `filename` to vp object. It contains the filename (path) that was fed to `readvp()`:

```r
> str(vp_files[[1]])

chr "../data/raw/example/seang_vp_20161003T2000Z.h5" # This is new
$ radar     : chr "SE50"
$ datetime  : POSIXct[1:1], format: "2016-10-03 20:00:00"
$ data      :'data.frame':	25 obs. of  16 variables:
...
$ attributes:List of 3
```

As this is a new attribute, it should not affect any existing code.

This functionality already comes in handy in https://github.com/enram/vp-processing, where the filename is used to get a consistent radar id (and datetime): see https://github.com/enram/vp-processing/issues/18.