### PR TITLE
Add biocViews to automatically look for rhdf5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bioRad
 Title: Biological analysis and visualization of weather radar data
-Version: 0.3.1
+Version: 0.3.0.9151
 Description: Extracts and visualizes biological signals from weather radar data.
 Authors@R: c(
     person("Adriaan M.", "Dokter", role = c("aut", "cre"), email = "amd427@cornell.edu", comment = c(ORCID = "0000-0001-6573-066X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ Authors@R: c(
 License: MIT + file LICENSE
 URL: https://github.com/adokter/bioRad, https://adokter.github.io/bioRad
 BugReports: https://github.com/adokter/bioRad/issues
+biocViews:
 Depends:
     R (>= 2.10)
 Imports:


### PR DESCRIPTION
From [this stack exchange](https://bioinformatics.stackexchange.com/questions/3365/r-package-development-how-does-one-automatically-install-bioconductor-packages) it looks like including `biocViews:` to the DESCRIPTION allows the installation to look for bioconductor dependencies as well. If true, it means users don't have to do:

```r
source("http://bioconductor.org/biocLite.R")
biocLite("rhdf5")
````

before installing bioRad, which would simplify things nicely. I'll test this first.