### PR TITLE
Updated year in Dokter et al. reference to 2019

### DIFF
--- a/R/bioRad.R
+++ b/R/bioRad.R
@@ -2,7 +2,7 @@
 #' To get started, see:
 #'
 #' \itemize{
-#'   \item \href{https://doi.org/10.1111/ecog.04028}{Dokter et al. (2018)}: a
+#'   \item \href{https://doi.org/10.1111/ecog.04028}{Dokter et al. (2019)}: a
 #'   paper describing the package.
 #'   \item \href{https://adokter.github.io/bioRad/articles/bioRad.html}{bioRad
 #'   vignette}: an introduction to bioRad's main functionalities.

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ bioRad provides standardized methods for extracting and reporting biological sig
 
 To get started, see:
 
-* [Dokter et al. (2018)](https://doi.org/10.1111/ecog.04028): a paper describing the package.
+* [Dokter et al. (2019)](https://doi.org/10.1111/ecog.04028): a paper describing the package.
 * [bioRad vignette](https://adokter.github.io/bioRad/articles/bioRad.html): an introduction to bioRad's main functionalities.
 * [Function reference](https://adokter.github.io/bioRad/reference/index.html): an overview of all bioRad functions.
 * [Introductory exercises](https://adokter.github.io/bioRad/articles/rad_aero_18.html): a tutorial with code examples and exercises.

--- a/README.md
+++ b/README.md
@@ -40,12 +40,6 @@ Then load the package with:
 
 ```r
 library(bioRad)
-#> Welcome to bioRad version 0.4.0
-#> Warning: no running Docker daemon found Warning: bioRad
-#> functionality requiring Docker has been disabled
-#> 
-#> To enable Docker functionality, start Docker and run
-#> 'check_docker()' in R
 ```
 
 ### _Attention!_ 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ bioRad provides standardized methods for extracting and reporting biological sig
 
 To get started, see:
 
-* [Dokter et al. (2018)](https://doi.org/10.1111/ecog.04028): a paper describing the package.
+* [Dokter et al. (2019)](https://doi.org/10.1111/ecog.04028): a paper describing the package.
 * [bioRad vignette](https://adokter.github.io/bioRad/articles/bioRad.html): an introduction to bioRad's main functionalities.
 * [Function reference](https://adokter.github.io/bioRad/reference/index.html): an overview of all bioRad functions.
 * [Introductory exercises](https://adokter.github.io/bioRad/articles/rad_aero_18.html): a tutorial with code examples and exercises.
@@ -40,6 +40,12 @@ Then load the package with:
 
 ```r
 library(bioRad)
+#> Welcome to bioRad version 0.4.0
+#> Warning: no running Docker daemon found Warning: bioRad
+#> functionality requiring Docker has been disabled
+#> 
+#> To enable Docker functionality, start Docker and run
+#> 'check_docker()' in R
 ```
 
 ### _Attention!_ 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -4,9 +4,9 @@ citEntry(entry = "article",
   title = "bioRad: biological analysis and visualization of weather radar data",
   author = c(person(c("Adriaan", "M."), "Dokter"), person("Peter", "Desmet"), person(c("Jurriaan","H."), "Spaaks"), person("Stijn", "Van Hoey"), person("Lourens", "Veen"), person("Liesbeth", "Verlinden"), person("Cecilia","Nilsson"), person("Günther","Haase"), person("Hidde","Leijnse"), person("Andrew","Farnsworth"), person("Willem","Bouten"), person("Judy","Shamoun-Baranes")),
   journal="Ecography",
-  year="2018",
-  volume="",
-  pages="",
+  year="2019",
+  volume="42",
+  pages="852-860",
   doi="10.1111/ecog.04028",
-  textVersion="Dokter AM, Desmet P, Spaaks JH, Van Hoey S, Veen L, Verlinden L, Nilsson C, Haase G, Leijnse H, Farnsworth A, Bouten W, Shamoun-Baranes S (2018) bioRad: biological analysis and visualization of weather radar data. Ecography. https://doi.org/10.1111/ecog.04028"
+  textVersion="Dokter AM, Desmet P, Spaaks JH, Van Hoey S, Veen L, Verlinden L, Nilsson C, Haase G, Leijnse H, Farnsworth A, Bouten W, Shamoun-Baranes S (2019) bioRad: biological analysis and visualization of weather radar data. Ecography 42: 852-860. https://doi.org/10.1111/ecog.04028"
 )

--- a/vignettes/bioRad.Rmd
+++ b/vignettes/bioRad.Rmd
@@ -10,9 +10,9 @@ vignette: >
 
 bioRad is an R package for the biological analysis and visualization of weather radar data. The package is described in our paper:
 
-> Dokter AM, Desmet P, Spaaks JH, Van Hoey S, Veen L, Verlinden L, Nilsson C, Haase G, Leijnse H, Farnsworth A, Bouten W, Shamoun-Baranes S (2018) bioRad: biological analysis and visualization of weather radar data. Ecography. <https://doi.org/10.1111/ecog.04028>
+> Dokter AM, Desmet P, Spaaks JH, Van Hoey S, Veen L, Verlinden L, Nilsson C, Haase G, Leijnse H, Farnsworth A, Bouten W, Shamoun-Baranes S (2019) bioRad: biological analysis and visualization of weather radar data. Ecography 42: 852-860. <https://doi.org/10.1111/ecog.04028>
 
-The [paper][dokter_2018] also defines weather radar equivalents for familiar measures used in the field of migration ecology and is thus a good start if you are new to radar aeroecology. Below we included the sections and figure from the paper describing the package and typical analysis workflow, with links to the functions used.
+The [paper][dokter_2019] also defines weather radar equivalents for familiar measures used in the field of migration ecology and is thus a good start if you are new to radar aeroecology. Below we included the sections and figure from the paper describing the package and typical analysis workflow, with links to the functions used.
 
 In the top navigation, see [**Reference**](https://adokter.github.io/bioRad/reference/index.html) for an overview of all functions, [**Articles**](https://adokter.github.io/bioRad/articles/index.html) for course exercises and [**Changelog**](https://adokter.github.io/bioRad/news/index.html) for package updates.
 
@@ -25,7 +25,7 @@ In the top navigation, see [**Reference**](https://adokter.github.io/bioRad/refe
 [chilson_2012b]: https://doi.org/10.1890/ES12-00027.1
 [dokter_2011]: https://doi.org/10.1098/rsif.2010.0116
 [dokter_2013]: https://doi.org/10.1371/journal.pone.0052300
-[dokter_2018]: https://doi.org/10.1111/ecog.04028
+[dokter_2019]: https://doi.org/10.1111/ecog.04028
 [haase_2004]: https://doi.org/10.1175/1520-0426(2004)021%3C1566:DODRVU%3E2.0.CO;2
 [holleman_2005]: https://doi.org/10.1175/JTECH1781.1
 [huuskonen_2014]: https://doi.org/10.1175/BAMS-D-12-00216.1
@@ -51,7 +51,7 @@ The underlying C‐code for the algorithm has been refactored for compatibility 
 
 ## Figure 2
 
-![**Figure 2 from [Dokter et al. (2018)][dokter_2018]**](ecog12354-fig-0002-m.jpg)
+![**Figure 2 from [Dokter et al. (2019)][dokter_2019]**](ecog12354-fig-0002-m.jpg)
 
 The figure shows the structure and interrelation of bioRad's main class objects, functions, and plotting methods. (A) **objects** (rounded box), **functions** (`fixed width font`) and their **relation** (arrows). (B–K) output of the default plot methods for a European radar (left row, Offenthal radar, Germany, 2016‐10‐04 15:15 UTC–2016‐10‐05 08:45 UTC) and US radar (right row, KBRO radar, Texas, 2017‐05‐14 00:09 UTC–2017‐05‐14 13:25 UTC). The dotted line in (H) and (K) indicates the time slice of (B), (D), (F) and (C), (E), (J) respectively. Grey shading indicates night time (time on the x‐axis is in UTC). Altitudes are relative to mean sea level.
 


### PR DESCRIPTION
With the [special issue](https://onlinelibrary.wiley.com/doi/toc/10.1111/(ISSN)1600-0587.radar-aeroecology) published, Dokter et al. should now have the year 2019 instead of 2018 (thanks for notifying @CeciliaNilsson709 👌). Updated everywhere the paper is mentioned.