### PR TITLE
Fix: Correctly number azimuths in scan plot

### DIFF
--- a/R/plot.scan.R
+++ b/R/plot.scan.R
@@ -70,7 +70,7 @@ plot.scan <- function(x, param, xlim = c(0, 100),
   # convert to points
   dimraster <- dim(data)
   data <- data.frame(rasterToPoints(raster(data)))
-  data$x <- (1 - data$x) * dimraster[2] * c(x$attributes$where$nrays) / 360
+  data$x <- (data$x / max(data$x)) * dimraster[2] * 360 / c(x$attributes$where$nrays)
   data$y <- (1 - data$y) * dimraster[1] * c(x$attributes$where$rscale) / 1000
   # change the name from "layer" to the parameter names
   names(data) <- c("azimuth", "range", param)


### PR DESCRIPTION
While manually trying to filter out rays with EM interference, I found out the rays are not numbered correctly when a `scan` is plotted. I'm not entirely sure how `raster()` converts the `x` values, but it should probably scale between 0-1, which it does not.

See the example below.

**Reference PPI**
![PPI](https://user-images.githubusercontent.com/27130/71471564-24110f00-27d0-11ea-9298-8a87fd6cb68a.png)

EM interference in the PPI is in the 201-202° and 214-215° rays, which matches nicely with the raw data. However, plotting the scan with the incorrect code shows the interference shifted much closer to 155°.

| Incorrect `scan` plot | Corrected `scan` plot |
| --- | --- |
| ![Incorrect_Scan](https://user-images.githubusercontent.com/27130/71471010-5de11600-27ce-11ea-83af-4e4d47cd717f.png) |  ![Corrected_Scan](https://user-images.githubusercontent.com/27130/71471118-d3e57d00-27ce-11ea-9112-a2507dd10143.png) |