### PR TITLE
new options in sunrise(), sunset() and check_night()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * new option `keep_timestamp` in `regularize_vpts()`, which allows individual profiles to keep there original timestamp instead of the timestamp of the regularized grid
 
+* improved documentation of sunrise/sunset functions (#180) and new option `force_tz` (4968019)
+
 # bioRad 0.5.1
 
 Minor bugfixes. All issues included in this release can be found [here](https://github.com/adokter/bioRad/pull/334). This release primarily fixes a bug that will become effective once R version 4.0 is released.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,11 @@
 
 * `regularize_vpts()` is now much faster, and chooses more intuitive starting and ending point of the regularized grid, e.g. projecting on half hour grid will have time series start on the nearest half hour (#332)
 
-* new option `keep_timestamp` in `regularize_vpts()`, which allows individual profiles to keep there original timestamp instead of the timestamp of the regularized grid
+* new option `keep_timestamp` in `regularize_vpts()`, which allows individual profiles to keep there original timestamp instead of the timestamp of the regularized grid.
 
-* improved documentation of sunrise/sunset functions (#180) and new option `force_tz` (4968019)
+* improved documentation of sunrise/sunset functions (#180) and new option `force_tz` (4968019).
+
+* new option `offset` in `check_night()`, which allows day/night transition to be shifted by a temporal offset (#338). For example, this is useful when selecting night time profiles that start a specific number of hours after sunset.
 
 # bioRad 0.5.1
 

--- a/R/check_night.R
+++ b/R/check_night.R
@@ -46,6 +46,11 @@
 #' check_night(example_vp)
 #'
 #' check_night(example_vpts)
+#'
+#' # select nighttime profiles that are between 3 hours after sunset
+#' # and 2 hours before sunrise:
+#' index <- check_night(example_vpts, offset=c(3,-2)*3600)
+#' example_vpts[index]
 check_night <- function(x, ..., elev = -0.268, offset = 0) {
   UseMethod("check_night", x)
 }

--- a/R/sunrise_sunset.R
+++ b/R/sunrise_sunset.R
@@ -13,7 +13,15 @@
 #' @return The moment of sunrise or sunset for the date set by \code{date}and time zone as specified
 #' (by \code{date} and \code{tz}) or in UTC if not specified.
 #'
-#' @details The angular diameter of the sun is about 0.536 degrees,
+#' @details
+#' The day for which sunrise and sunset are calcuated is given by the input date.
+#' Sunrise and sunset are calculated relative to the moment of solar noon for that date,
+#' i.e. the first sunrise before the moment of solar noon, and the first sunset after the
+#' moment of solar noon. Therefore, depending on the timezone provided, it is possible that
+#' the nearest sunrise prior to solar noon occurs a day earlier than the input date.
+#' Similarly, sunset may occur a day later than the input date. See examples for details.
+#'
+#' The angular diameter of the sun is about 0.536 degrees,
 #' therefore the moment of sunrise/sunset corresponds to half that elevation
 #' at -0.268 degrees.
 #'
@@ -21,9 +29,6 @@
 #'
 #' Approximate astronomical formula are used, therefore the moment of
 #' sunrise / sunset may be off by a few minutes
-#'
-#' Sunrise and sunset is given for the day specified by \code{date}, with sunset always
-#' later than sunrise given the same \code{date}.
 #'
 #' If \code{force_tz} is \code{TRUE}, the input date is converted to the timezone
 #' set by \code{tz} prior to calculating the sunrise/sunset time, resulting in a shift by +/-1 day
@@ -35,8 +40,38 @@
 #' # sunset in the Netherlands
 #' sunset("2016-01-01", 5, 53)
 #'
-#' # civil twilight in Ithaca, NY, today
-#' sunrise(Sys.time(), -76.5, 42.4, elev = -6)
+#' # civil twilight in Ithaca, NY
+#' sunrise("2016-01-01", -76.5, 42.4, elev = -6)
+#'
+#' # next sunset in South Dakota, USA
+#' sunset("2016-11-15", -98, 45)
+#'
+#' # Beware that some days have two sunsets, or
+#' # two sunrises! E.g. on 5 Oct (local timezone) at
+#' # this location  sunset is actually on the 6 Oct
+#' # in UTC time zone, i.e. the next day
+#' sunset("2016-10-5", -98, 45)
+#' # One day later, sunset is again on 6 Oct:
+#' sunset("2016-10-6", -98, 45)
+#'
+#' # working in local time zones typically avoids such ambiguities:
+#' sunset(as_datetime("2016-06-05",tz="America/Chicago"), -98, 45)
+#' sunset(as_datetime("2016-06-06",tz="America/Chicago"), -98, 45)
+#'
+#' # use force_tz to force output to a specific time zone, by default UTC:
+#' sunset(as_datetime("2016-06-05",tz="America/Chicago"), -98, 45, force_tz=T)
+#' sunset(as_datetime("2016-06-06",tz="America/Chicago"), -98, 45, force_tz=T)
+#'
+#' # Also beware of jumps in sunrise and sunset date with longitude:
+#' sunrise("2016-11-01", 100, 45)
+#' sunrise("2016-11-01", 102, 45)
+#'
+#' # sunrise date can even be two days earlier in specific cases:
+#' # e.g. "2016-10-31 00:00" in Asia/Ulaanbaatar time zone is converted to
+#' # 2016-10-30 16:00 UTC when force_tz=TRUE. Solar noon on 2016-10-30 at this
+#' location in Mongolia is at 04:55 UTC, and the first sunrise prior to this
+#' is on 2016-10-29:
+#' sunrise(as_datetime("2016-10-31",tz="Asia/Ulaanbaatar"), 120, 45, tz="UTC", force_tz=T)
 #' @name sunrise_sunset
 NULL
 

--- a/R/sunrise_sunset.R
+++ b/R/sunrise_sunset.R
@@ -9,7 +9,8 @@
 #' @param elev Sun elevation in degrees.
 #' @param tz output time zone. Ignored if \code{date} has an associated time zone already
 #'
-#' @return The moment of sunrise or sunset in UTC time.
+#' @return The moment of sunrise or sunset in the same time zone as specified
+#' (by \code{date} or \code{tz}) or in UTC if not specified.
 #'
 #' @details The angular diameter of the sun is about 0.536 degrees,
 #' therefore the moment of sunrise/sunset corresponds to half that elevation

--- a/R/sunrise_sunset.R
+++ b/R/sunrise_sunset.R
@@ -31,7 +31,8 @@
 #' sunrise / sunset may be off by a few minutes
 #'
 #' If \code{force_tz} is \code{TRUE}, the input date is converted to the timezone
-#' set by \code{tz} prior to calculating the sunrise/sunset time, resulting in a shift by +/-1 day
+#' set by \code{tz} prior to calculating the sunrise/sunset time, possibly resulting
+#' in an additional day shift in the output by +/-1 day
 #'
 #' @examples
 #' # sunrise in the Netherlands

--- a/R/sunrise_sunset.R
+++ b/R/sunrise_sunset.R
@@ -8,9 +8,10 @@
 #' @param lat Latitude in decimal degrees.
 #' @param elev Sun elevation in degrees.
 #' @param tz output time zone. Ignored if \code{date} has an associated time zone already
+#' @param force_tz whether to convert input time to timezone \code{tz}. Default \code{FALSE}.
 #'
-#' @return The moment of sunrise or sunset in the same time zone as specified
-#' (by \code{date} or \code{tz}) or in UTC if not specified.
+#' @return The moment of sunrise or sunset for the date set by \code{date}and time zone as specified
+#' (by \code{date} and \code{tz}) or in UTC if not specified.
 #'
 #' @details The angular diameter of the sun is about 0.536 degrees,
 #' therefore the moment of sunrise/sunset corresponds to half that elevation
@@ -20,6 +21,12 @@
 #'
 #' Approximate astronomical formula are used, therefore the moment of
 #' sunrise / sunset may be off by a few minutes
+#'
+#' Sunrise and sunset is given for the day specified by \code{date}, with sunset always
+#' later than sunrise given the same \code{date}.
+#'
+#' If \code{force_tz} is \code{TRUE}, the input date is converted to the timezone
+#' set by \code{tz} prior to calculating the sunrise/sunset time, resulting in a shift by +/-1 day
 #'
 #' @examples
 #' # sunrise in the Netherlands
@@ -36,10 +43,11 @@ NULL
 #' @rdname sunrise_sunset
 #'
 #' @export
-sunrise <- function(date, lon, lat, elev = -0.268, tz = "UTC") {
+sunrise <- function(date, lon, lat, elev = -0.268, tz = "UTC", force_tz = FALSE) {
   locations <- data.frame(lon = lon, lat = lat)
   locations <- SpatialPoints(locations, proj4string = CRS("+proj=longlat +datum=WGS84"))
-  datetime <- as.POSIXct(date, tz = tz)
+  datetime <- as.POSIXct(date, tz = tz) # tz ignored if already set
+  if(force_tz) datetime <- as_datetime(datetime, tz=tz)
   suntimes <- crepuscule(locations, datetime, solarDep = -elev, direction = "dawn", POSIXct.out = TRUE)
   suntimes$time
 }
@@ -47,10 +55,11 @@ sunrise <- function(date, lon, lat, elev = -0.268, tz = "UTC") {
 #' @rdname sunrise_sunset
 #'
 #' @export
-sunset <- function(date, lon, lat, elev = -0.268, tz = "UTC") {
+sunset <- function(date, lon, lat, elev = -0.268, tz = "UTC", force_tz = FALSE) {
   locations <- data.frame(lon = lon, lat = lat)
   locations <- SpatialPoints(locations, proj4string = CRS("+proj=longlat +datum=WGS84"))
-  datetime <- as.POSIXct(date, tz = tz)
+  datetime <- as.POSIXct(date, tz = tz) # tz ignored if already set
+  if(force_tz) datetime <- as_datetime(datetime, tz=tz)
   suntimes <- crepuscule(locations, datetime, solarDep = -elev, direction = "dusk", POSIXct.out = TRUE)
   suntimes$time
 }

--- a/R/sunrise_sunset.R
+++ b/R/sunrise_sunset.R
@@ -8,7 +8,7 @@
 #' @param lat Latitude in decimal degrees.
 #' @param elev Sun elevation in degrees.
 #' @param tz output time zone. Ignored if \code{date} has an associated time zone already
-#' @param force_tz whether to convert input and output datetimes to timezone \code{tz}. Default \code{FALSE}.
+#' @param force_tz whether to convert output to timezone \code{tz}. Default \code{FALSE}.
 #'
 #' @return The moment of sunrise or sunset for the date set by \code{date}and time zone as specified
 #' (by \code{date} and \code{tz}) or in UTC if not specified.
@@ -30,9 +30,8 @@
 #' Approximate astronomical formula are used, therefore the moment of
 #' sunrise / sunset may be off by a few minutes
 #'
-#' If \code{force_tz} is \code{TRUE}, the input date is converted to the timezone
-#' set by \code{tz} prior to calculating the sunrise/sunset time, possibly resulting
-#' in an additional day shift in the output by +/-1 day
+#' If \code{force_tz} is \code{TRUE}, the output is converted to the timezone
+#' set by \code{tz}
 #'
 #' @examples
 #' # sunrise in the Netherlands
@@ -67,12 +66,6 @@
 #' sunrise("2016-11-01", 100, 45)
 #' sunrise("2016-11-01", 102, 45)
 #'
-#' # sunrise date can even be two days earlier in specific cases:
-#' # e.g. "2016-10-31 00:00" in Asia/Ulaanbaatar time zone is converted to
-#' # 2016-10-30 16:00 UTC when force_tz=TRUE. Solar noon on 2016-10-30 at this
-#' location in Mongolia is at 04:55 UTC, and the first sunrise prior to this
-#' is on 2016-10-29:
-#' sunrise(as_datetime("2016-10-31",tz="Asia/Ulaanbaatar"), 120, 45, tz="UTC", force_tz=T)
 #' @name sunrise_sunset
 NULL
 
@@ -83,8 +76,8 @@ sunrise <- function(date, lon, lat, elev = -0.268, tz = "UTC", force_tz = FALSE)
   locations <- data.frame(lon = lon, lat = lat)
   locations <- SpatialPoints(locations, proj4string = CRS("+proj=longlat +datum=WGS84"))
   datetime <- as.POSIXct(date, tz = tz) # tz ignored if already set
-  if(force_tz) datetime <- as_datetime(datetime, tz=tz)
   suntimes <- crepuscule(locations, datetime, solarDep = -elev, direction = "dawn", POSIXct.out = TRUE)
+  if(force_tz) suntimes$time <- as_datetime(suntimes$time, tz=tz)
   suntimes$time
 }
 
@@ -95,7 +88,7 @@ sunset <- function(date, lon, lat, elev = -0.268, tz = "UTC", force_tz = FALSE) 
   locations <- data.frame(lon = lon, lat = lat)
   locations <- SpatialPoints(locations, proj4string = CRS("+proj=longlat +datum=WGS84"))
   datetime <- as.POSIXct(date, tz = tz) # tz ignored if already set
-  if(force_tz) datetime <- as_datetime(datetime, tz=tz)
   suntimes <- crepuscule(locations, datetime, solarDep = -elev, direction = "dusk", POSIXct.out = TRUE)
+  if(force_tz) suntimes$time <- as_datetime(suntimes$time, tz=tz)
   suntimes$time
 }

--- a/R/sunrise_sunset.R
+++ b/R/sunrise_sunset.R
@@ -8,7 +8,7 @@
 #' @param lat Latitude in decimal degrees.
 #' @param elev Sun elevation in degrees.
 #' @param tz output time zone. Ignored if \code{date} has an associated time zone already
-#' @param force_tz whether to convert input time to timezone \code{tz}. Default \code{FALSE}.
+#' @param force_tz whether to convert input and output datetimes to timezone \code{tz}. Default \code{FALSE}.
 #'
 #' @return The moment of sunrise or sunset for the date set by \code{date}and time zone as specified
 #' (by \code{date} and \code{tz}) or in UTC if not specified.

--- a/man/check_night.Rd
+++ b/man/check_night.Rd
@@ -9,17 +9,17 @@
 \alias{check_night.pvol}
 \title{Check if it is night at a given time and place}
 \usage{
-check_night(x, ..., elev = -0.268)
+check_night(x, ..., elev = -0.268, offset = 0)
 
-\method{check_night}{default}(x, lon, lat, ..., tz = "UTC", elev = -0.268)
+\method{check_night}{default}(x, lon, lat, ..., tz = "UTC", elev = -0.268, offset = 0)
 
-\method{check_night}{vp}(x, ..., elev = -0.268)
+\method{check_night}{vp}(x, ..., elev = -0.268, offset = 0)
 
-\method{check_night}{list}(x, ..., elev = -0.268)
+\method{check_night}{list}(x, ..., elev = -0.268, offset = 0)
 
-\method{check_night}{vpts}(x, ..., elev = -0.268)
+\method{check_night}{vpts}(x, ..., elev = -0.268, offset = 0)
 
-\method{check_night}{pvol}(x, ..., elev = -0.268)
+\method{check_night}{pvol}(x, ..., elev = -0.268, offset = 0)
 }
 \arguments{
 \item{x}{\code{pvol}, \code{vp} or \code{vpts},
@@ -28,7 +28,12 @@ interpretable by \link{as.POSIXct}.}
 
 \item{...}{optional lat,lon arguments.}
 
-\item{elev}{numeric. Sun elevation in degrees.}
+\item{elev}{numeric. Sun elevation in degrees defining night time. May also be a numeric vector of
+length two, with first element giving sunset elevation, and second element sunrise elevation.}
+
+\item{offset}{numeric. Time duration in seconds by which the shift the start and end
+of night time. May also be a numeric vector of length two, with first element added to moment
+of sunset and second element added to moment of sunrise.}
 
 \item{lon}{numeric. Longitude in decimal degrees.}
 
@@ -57,6 +62,10 @@ elevation than parameter \code{elev}, otherwise \code{TRUE}.
 
 Approximate astronomical formula are used, therefore the day/night
 transition may be off by a few minutes.
+
+\code{offset} can be used to shift the moment of sunset and sunrise by a
+temporal offset, for example, \code{offset=c(600,-600)} will assume nighttime
+starts 600 seconds after sunset (as defined by \code{elev}) and stops 600 seconds before sunrise.
 }
 \examples{
 # check if it is night at UTC midnight in the Netherlands on January 1st:

--- a/man/check_night.Rd
+++ b/man/check_night.Rd
@@ -75,4 +75,9 @@ check_night("2016-01-01 00:00", 5, 53)
 check_night(example_vp)
 
 check_night(example_vpts)
+
+# select nighttime profiles that are between 3 hours after sunset
+# and 2 hours before sunrise:
+index <- check_night(example_vpts, offset=c(3,-2)*3600)
+example_vpts[index]
 }

--- a/man/sunrise_sunset.Rd
+++ b/man/sunrise_sunset.Rd
@@ -32,6 +32,13 @@ The moment of sunrise or sunset for the date set by \code{date}and time zone as 
 Calculate sunrise or sunset for a time and place
 }
 \details{
+The day for which sunrise and sunset are calcuated is given by the input date.
+Sunrise and sunset are calculated relative to the moment of solar noon for that date,
+i.e. the first sunrise before the moment of solar noon, and the first sunset after the
+moment of solar noon. Therefore, depending on the timezone provided, it is possible that
+the nearest sunrise prior to solar noon occurs a day earlier than the input date.
+Similarly, sunset may occur a day later than the input date. See examples for details.
+
 The angular diameter of the sun is about 0.536 degrees,
 therefore the moment of sunrise/sunset corresponds to half that elevation
 at -0.268 degrees.
@@ -40,9 +47,6 @@ This is a convenience function mapping to \link{crepuscule}.
 
 Approximate astronomical formula are used, therefore the moment of
 sunrise / sunset may be off by a few minutes
-
-Sunrise and sunset is given for the day specified by \code{date}, with sunset always
-later than sunrise given the same \code{date}.
 
 If \code{force_tz} is \code{TRUE}, the input date is converted to the timezone
 set by \code{tz} prior to calculating the sunrise/sunset time, resulting in a shift by +/-1 day
@@ -54,6 +58,36 @@ sunrise("2016-01-01", 5, 53)
 # sunset in the Netherlands
 sunset("2016-01-01", 5, 53)
 
-# civil twilight in Ithaca, NY, today
-sunrise(Sys.time(), -76.5, 42.4, elev = -6)
+# civil twilight in Ithaca, NY
+sunrise("2016-01-01", -76.5, 42.4, elev = -6)
+
+# next sunset in South Dakota, USA
+sunset("2016-11-15", -98, 45)
+
+# Beware that some days have two sunsets, or
+# two sunrises! E.g. on 5 Oct (local timezone) at
+# this location  sunset is actually on the 6 Oct
+# in UTC time zone, i.e. the next day
+sunset("2016-10-5", -98, 45)
+# One day later, sunset is again on 6 Oct:
+sunset("2016-10-6", -98, 45)
+
+# working in local time zones typically avoids such ambiguities:
+sunset(as_datetime("2016-06-05",tz="America/Chicago"), -98, 45)
+sunset(as_datetime("2016-06-06",tz="America/Chicago"), -98, 45)
+
+# use force_tz to force output to a specific time zone, by default UTC:
+sunset(as_datetime("2016-06-05",tz="America/Chicago"), -98, 45, force_tz=T)
+sunset(as_datetime("2016-06-06",tz="America/Chicago"), -98, 45, force_tz=T)
+
+# Also beware of jumps in sunrise and sunset date with longitude:
+sunrise("2016-11-01", 100, 45)
+sunrise("2016-11-01", 102, 45)
+
+# sunrise date can even be two days earlier in specific cases:
+# e.g. "2016-10-31 00:00" in Asia/Ulaanbaatar time zone is converted to
+# 2016-10-30 16:00 UTC when force_tz=TRUE. Solar noon on 2016-10-30 at this
+location in Mongolia is at 04:55 UTC, and the first sunrise prior to this
+is on 2016-10-29:
+sunrise(as_datetime("2016-10-31",tz="Asia/Ulaanbaatar"), 120, 45, tz="UTC", force_tz=T)
 }

--- a/man/sunrise_sunset.Rd
+++ b/man/sunrise_sunset.Rd
@@ -49,7 +49,8 @@ Approximate astronomical formula are used, therefore the moment of
 sunrise / sunset may be off by a few minutes
 
 If \code{force_tz} is \code{TRUE}, the input date is converted to the timezone
-set by \code{tz} prior to calculating the sunrise/sunset time, resulting in a shift by +/-1 day
+set by \code{tz} prior to calculating the sunrise/sunset time, possibly resulting
+in an additional day shift in the output by +/-1 day
 }
 \examples{
 # sunrise in the Netherlands

--- a/man/sunrise_sunset.Rd
+++ b/man/sunrise_sunset.Rd
@@ -22,7 +22,7 @@ interpretable by \link[base]{as.Date}.}
 
 \item{tz}{output time zone. Ignored if \code{date} has an associated time zone already}
 
-\item{force_tz}{whether to convert input and output datetimes to timezone \code{tz}. Default \code{FALSE}.}
+\item{force_tz}{whether to convert output to timezone \code{tz}. Default \code{FALSE}.}
 }
 \value{
 The moment of sunrise or sunset for the date set by \code{date}and time zone as specified
@@ -48,9 +48,8 @@ This is a convenience function mapping to \link{crepuscule}.
 Approximate astronomical formula are used, therefore the moment of
 sunrise / sunset may be off by a few minutes
 
-If \code{force_tz} is \code{TRUE}, the input date is converted to the timezone
-set by \code{tz} prior to calculating the sunrise/sunset time, possibly resulting
-in an additional day shift in the output by +/-1 day
+If \code{force_tz} is \code{TRUE}, the output is converted to the timezone
+set by \code{tz}
 }
 \examples{
 # sunrise in the Netherlands
@@ -85,10 +84,4 @@ sunset(as_datetime("2016-06-06",tz="America/Chicago"), -98, 45, force_tz=T)
 sunrise("2016-11-01", 100, 45)
 sunrise("2016-11-01", 102, 45)
 
-# sunrise date can even be two days earlier in specific cases:
-# e.g. "2016-10-31 00:00" in Asia/Ulaanbaatar time zone is converted to
-# 2016-10-30 16:00 UTC when force_tz=TRUE. Solar noon on 2016-10-30 at this
-location in Mongolia is at 04:55 UTC, and the first sunrise prior to this
-is on 2016-10-29:
-sunrise(as_datetime("2016-10-31",tz="Asia/Ulaanbaatar"), 120, 45, tz="UTC", force_tz=T)
 }

--- a/man/sunrise_sunset.Rd
+++ b/man/sunrise_sunset.Rd
@@ -6,9 +6,9 @@
 \alias{sunset}
 \title{Calculate sunrise or sunset for a time and place}
 \usage{
-sunrise(date, lon, lat, elev = -0.268, tz = "UTC")
+sunrise(date, lon, lat, elev = -0.268, tz = "UTC", force_tz = FALSE)
 
-sunset(date, lon, lat, elev = -0.268, tz = "UTC")
+sunset(date, lon, lat, elev = -0.268, tz = "UTC", force_tz = FALSE)
 }
 \arguments{
 \item{date}{Date inheriting from class \code{POSIXt} or a string
@@ -21,10 +21,12 @@ interpretable by \link[base]{as.Date}.}
 \item{elev}{Sun elevation in degrees.}
 
 \item{tz}{output time zone. Ignored if \code{date} has an associated time zone already}
+
+\item{force_tz}{whether to convert input time to timezone \code{tz}. Default \code{FALSE}.}
 }
 \value{
-The moment of sunrise or sunset in the same time zone as specified
-(by \code{date} or \code{tz}) or in UTC if not specified.
+The moment of sunrise or sunset for the date set by \code{date}and time zone as specified
+(by \code{date} and \code{tz}) or in UTC if not specified.
 }
 \description{
 Calculate sunrise or sunset for a time and place
@@ -38,6 +40,12 @@ This is a convenience function mapping to \link{crepuscule}.
 
 Approximate astronomical formula are used, therefore the moment of
 sunrise / sunset may be off by a few minutes
+
+Sunrise and sunset is given for the day specified by \code{date}, with sunset always
+later than sunrise given the same \code{date}.
+
+If \code{force_tz} is \code{TRUE}, the input date is converted to the timezone
+set by \code{tz} prior to calculating the sunrise/sunset time, resulting in a shift by +/-1 day
 }
 \examples{
 # sunrise in the Netherlands

--- a/man/sunrise_sunset.Rd
+++ b/man/sunrise_sunset.Rd
@@ -22,7 +22,7 @@ interpretable by \link[base]{as.Date}.}
 
 \item{tz}{output time zone. Ignored if \code{date} has an associated time zone already}
 
-\item{force_tz}{whether to convert input time to timezone \code{tz}. Default \code{FALSE}.}
+\item{force_tz}{whether to convert input and output datetimes to timezone \code{tz}. Default \code{FALSE}.}
 }
 \value{
 The moment of sunrise or sunset for the date set by \code{date}and time zone as specified

--- a/man/sunrise_sunset.Rd
+++ b/man/sunrise_sunset.Rd
@@ -23,7 +23,8 @@ interpretable by \link[base]{as.Date}.}
 \item{tz}{output time zone. Ignored if \code{date} has an associated time zone already}
 }
 \value{
-The moment of sunrise or sunset in UTC time.
+The moment of sunrise or sunset in the same time zone as specified
+(by \code{date} or \code{tz}) or in UTC if not specified.
 }
 \description{
 Calculate sunrise or sunset for a time and place


### PR DESCRIPTION
* improved documentation of sunrise/sunset functions (#180) and new option `force_tz` (4968019).

* new option `offset` in `check_night()`, which allows day/night transition to be shifted by a temporal offset (#338). For example, this is useful when selecting night time profiles that start a specific number of hours after sunset.