### PR TITLE
Enable Roxygen markdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,3 +47,4 @@ LazyData: true
 Encoding: UTF-8
 VignetteBuilder: knitr
 RoxygenNote: 7.1.0
+Roxygen: list(markdown = TRUE)

--- a/R/apply_mistnet.R
+++ b/R/apply_mistnet.R
@@ -38,7 +38,7 @@
 #' that should be removed when interested only in biological data.
 #'
 #' MistNet will calculate three class probabilities (from 0 to 1, with 1 corresponding
-#' to a 100\% probability) as additional scan parameters to the polar volume:
+#' to a 100% probability) as additional scan parameters to the polar volume:
 #' \describe{
 #' \item{"\code{BACKGROUND}"}{class probability that no signal was detected above the noise level of the radar}
 #' \item{"\code{WEATHER}"}{class probability that weather was detected}

--- a/R/beam.R
+++ b/R/beam.R
@@ -221,48 +221,62 @@ beam_profile_overlap_help <- function(vp, elev, distance, antenna = 0,
 #' Calculate overlap between a vertical profile ('vp') of biological scatterers
 #' and the vertical radiation profile emitted by the radar
 #'
-#' Calculates the distribution overlap between a vertical profile ('vp')
-#' and the vertical radiation profile of a set of emitted radar beams
-#' at various elevation angles as given by \link{beam_profile}.
+#' Calculates the distribution overlap between a vertical profile ('vp') and the
+#' vertical radiation profile of a set of emitted radar beams at various
+#' elevation angles as given by \link{beam_profile}.
 #'
-#' This function also calculates the \code{overlap} quantity in the output of \link{integrate_to_ppi}.
+#' This function also calculates the \code{overlap} quantity in the output of
+#' \link{integrate_to_ppi}.
 #' @inheritParams beam_height
 #' @inheritParams beam_width
 #' @param vp a vertical profile of class vp
 #' @param elev numeric vector. Beam elevation(s) in degrees.
-#' @param distance the distance(s) from the radar along sea level (down range) for which to calculate the overlap in m.
+#' @param distance the distance(s) from the radar along sea level (down range)
+#'   for which to calculate the overlap in m.
 #' @param zlim altitude range in meter, given as a numeric vector of length two.
-#' @param noise_floor The system noise floor in dBZ. The total system noise expressed as the reflectivity factor
-#'  it would represent at a distance \code{noise_floor_ref_range} from the radar. NOT YET IMPLEMENTED
-#' @param noise_floor_ref_range the reference distance from the radar at which \code{noise_floor} is expressed. NOT YET IMPLEMENTED
-#' @param steps number of integration steps over altitude range zlim, defining altitude grid size used for numeric integrations
-#' @param quantity profile quantity to use for the altitude distribution, one of 'dens' or 'eta'.
-#' @param normalize Whether to normalize the radiation coverage pattern over the altitude range specified by zlim
+#' @param noise_floor The system noise floor in dBZ. The total system noise
+#'   expressed as the reflectivity factor it would represent at a distance
+#'   \code{noise_floor_ref_range} from the radar. NOT YET IMPLEMENTED
+#' @param noise_floor_ref_range the reference distance from the radar at which
+#'   \code{noise_floor} is expressed. NOT YET IMPLEMENTED
+#' @param steps number of integration steps over altitude range zlim, defining
+#'   altitude grid size used for numeric integrations
+#' @param quantity profile quantity to use for the altitude distribution, one of
+#'   'dens' or 'eta'.
+#' @param normalize Whether to normalize the radiation coverage pattern over the
+#'   altitude range specified by zlim
 #' @param antenna radar antenna height. If missing taken from \code{vp}
 #' @param lat radar latitude. If missing taken from \code{vp}
 #' @return A data.frame with columns distance and overlap.
 #'
 #' @export
 #'
-#' @details  Overlap is calculated as the  [Bhattacharyya coefficient](https://en.wikipedia.org/wiki/Bhattacharyya_distance)
-#' (i.e. distribution overlap) between the (normalized) vertical profile vp and the (normalized)
-#' radiation coverage pattern as calculated by \link{beam_profile}.
+#' @details Overlap is calculated as the [Bhattacharyya
+#'   coefficient](https://en.wikipedia.org/wiki/Bhattacharyya_distance) (i.e.
+#'   distribution overlap) between the (normalized) vertical profile vp and the
+#'   (normalized) radiation coverage pattern as calculated by
+#'   \link{beam_profile}.
 #'
-#' The current implementation does not (yet) take into account the system noise floor when calculating
-#' the overlap.
+#'   The current implementation does not (yet) take into account the system
+#'   noise floor when calculating the overlap.
 #'
-#' In the ODIM data model the attribute \code{/how/NEZ} or \code{/how/NEZH} specifies the system noise floor
-#' (the Noise Equivalent Z or noise equivalent reflectivity factor. the H refers to the horizontal channel
-#' of a dual-polarization radar).
-#' In addition, the attribute \code{/how/LOG} gives "security distance above mean noise level (dB) threshold value".
-#' This is equivalent to the log receiver signal-to-noise ratio, i.e. the dB above the noise floor for the signal processor
-#' to report a valid reflectivity value. We recommend using \code{NEZH}+\code{LOG} for \code{noise_floor}, as this
-#' is the effective noise floor of the system below which no data will be reported by the radar signal processor.
+#'   In the ODIM data model the attribute \code{/how/NEZ} or \code{/how/NEZH}
+#'   specifies the system noise floor (the Noise Equivalent Z or noise
+#'   equivalent reflectivity factor. the H refers to the horizontal channel of a
+#'   dual-polarization radar). In addition, the attribute \code{/how/LOG} gives
+#'   "security distance above mean noise level (dB) threshold value". This is
+#'   equivalent to the log receiver signal-to-noise ratio, i.e. the dB above the
+#'   noise floor for the signal processor to report a valid reflectivity value.
+#'   We recommend using \code{NEZH}+\code{LOG} for \code{noise_floor}, as this
+#'   is the effective noise floor of the system below which no data will be
+#'   reported by the radar signal processor.
 #'
-#' Typical values are \code{NEZH} = -45 to -50 dBZ at 1 km from the radar. \code{LOG} is typically around 1 dB.
+#'   Typical values are \code{NEZH} = -45 to -50 dBZ at 1 km from the radar.
+#'   \code{LOG} is typically around 1 dB.
 #'
-#' Need to evaluate beam by beam the returned signal relative to a uniform beam filling of at least NEZH + LOG
-#' If returned signal is lower, the gate is below noise level.
+#'   Need to evaluate beam by beam the returned signal relative to a uniform
+#'   beam filling of at least NEZH + LOG If returned signal is lower, the gate
+#'   is below noise level.
 #'
 #' @examples
 #' # locate example volume file:

--- a/R/map.R
+++ b/R/map.R
@@ -31,15 +31,15 @@
 #' Available scan parameters for mapping can by printed to screen by
 #' \code{summary(x)}. Commonly available parameters are:
 #' \describe{
-#'  \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor [dBZ]}
-#'  \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor [dBZ]}
-#'  \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity [m/s]. Radial
+#'  \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor (dBZ)}
+#'  \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor (dBZ)}
+#'  \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity (m/s). Radial
 #'  velocities towards the radar are negative, while radial velocities away
 #'  from the radar are positive}
-#'  \item{"\code{RHOHV}"}{Correlation coefficient [unitless]. Correlation
+#'  \item{"\code{RHOHV}"}{Correlation coefficient (unitless) Correlation
 #'  between vertically polarized and horizontally polarized reflectivity factor}
-#'  \item{"\code{PHIDP}"}{Differential phase [degrees]}
-#'  \item{"\code{ZDR}"}{(Logged) differential reflectivity [dB]}
+#'  \item{"\code{PHIDP}"}{Differential phase (degrees)}
+#'  \item{"\code{ZDR}"}{(Logged) differential reflectivity (dB)}
 #' }
 #' The scan parameters are named according to the OPERA data information
 #' model (ODIM), see Table 16 in the

--- a/R/param.R
+++ b/R/param.R
@@ -15,11 +15,11 @@
 #' \describe{
 #'    \item{\code{radar}}{character string with the radar identifier}
 #'    \item{\code{datetime}}{nominal time of the volume to which this
-#'      scan belongs [UTC]}
-#'    \item{\code{lat}}{latitude of the radar [decimal degrees]}
-#'    \item{\code{lon}}{longitude of the radar [decimal degrees]}
-#'    \item{\code{height}}{height of the radar antenna [meters above sea level]}
-#'    \item{\code{get_elevation_angles}}{radar beam elevation [degrees]}
+#'      scan belongs (UTC)}
+#'    \item{\code{lat}}{latitude of the radar (decimal degrees)}
+#'    \item{\code{lon}}{longitude of the radar (decimal degrees)}
+#'    \item{\code{height}}{height of the radar antenna (meters above sea level)}
+#'    \item{\code{get_elevation_angles}}{radar beam elevation (degrees)}
 #'    \item{\code{param}}{string with the name of the polar scan parameter}
 #' }
 #' Scan parameters are named according to the OPERA data information model
@@ -27,15 +27,15 @@
 #' \href{https://github.com/adokter/vol2bird/blob/master/doc/OPERA2014_O4_ODIM_H5-v2.2.pdf}{ODIM specification}.
 #' Commonly available parameters are:
 #' \describe{
-#'  \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor [dBZ]}
-#'  \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity [m/s]. Radial
+#'  \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor (dBZ)}
+#'  \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity (m/s). Radial
 #'    velocities towards the radar are negative, while radial velocities away
 #'    from the radar are positive}
-#'  \item{"\code{RHOHV}"}{Correlation coefficient [unitless]. Correlation
+#'  \item{"\code{RHOHV}"}{Correlation coefficient (unitless). Correlation
 #'    between vertically polarized and horizontally polarized
 #'    reflectivity factor}
-#'  \item{"\code{PHIDP}"}{Differential phase [degrees]}
-#'  \item{"\code{ZDR}"}{(Logged) differential reflectivity [dB]}
+#'  \item{"\code{PHIDP}"}{Differential phase (degrees)}
+#'  \item{"\code{ZDR}"}{(Logged) differential reflectivity (dB)}
 #' }
 #' @examples
 #' # load example scan object

--- a/R/plot.ppi.R
+++ b/R/plot.ppi.R
@@ -20,15 +20,15 @@
 #' Available scan paramaters for plotting can by printed to screen
 #' by \code{summary(x)}. Commonly available parameters are:
 #' \describe{
-#'  \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor [dBZ]}
-#'  \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor [dBZ]}
-#'  \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity [m/s]. Radial
+#'  \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor (dBZ)}
+#'  \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor (dBZ)}
+#'  \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity (m/s). Radial
 #'  velocities towards the radar are negative, while radial velocities away
 #'  from the radar are positive}
-#'  \item{"\code{RHOHV}"}{Correlation coefficient [unitless]. Correlation
+#'  \item{"\code{RHOHV}"}{Correlation coefficient (unitless). Correlation
 #'  between vertically polarized and horizontally polarized reflectivity factor}
-#'  \item{"\code{PHIDP}"}{Differential phase [degrees]}
-#'  \item{"\code{ZDR}"}{(Logged) differential reflectivity [dB]}
+#'  \item{"\code{PHIDP}"}{Differential phase (degrees)}
+#'  \item{"\code{ZDR}"}{(Logged) differential reflectivity (dB)}
 #' }
 #' The scan parameters are named according to the OPERA data information
 #' model (ODIM), see Table 16 in the

--- a/R/plot.scan.R
+++ b/R/plot.scan.R
@@ -18,16 +18,16 @@
 #' Available scan parameters for plotting can by printed to screen
 #' by \code{summary(x)}. Commonly available parameters are:
 #' \describe{
-#'  \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor [dBZ]}
-#'  \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor [dBZ]}
-#'  \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity [m/s]. Radial
+#'  \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor (dBZ)}
+#'  \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor (dBZ)}
+#'  \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity (m/s). Radial
 #'    velocities towards the radar are negative, while radial velocities away
 #'    from the radar are positive}
-#'  \item{"\code{RHOHV}"}{Correlation coefficient [unitless]. Correlation
+#'  \item{"\code{RHOHV}"}{Correlation coefficient (unitless). Correlation
 #'    between vertically polarized and horizontally polarized
 #'    reflectivity factor}
-#'  \item{"\code{PHIDP}"}{Differential phase [degrees]}
-#'  \item{"\code{ZDR}"}{(Logged) differential reflectivity [dB]}
+#'  \item{"\code{PHIDP}"}{Differential phase (degrees)}
+#'  \item{"\code{ZDR}"}{(Logged) differential reflectivity (dB)}
 #' }
 #' The scan parameters are named according to the OPERA data information
 #' model (ODIM), see Table 16 in the

--- a/R/plot.vpi.R
+++ b/R/plot.vpi.R
@@ -11,10 +11,10 @@
 #' '\code{rtr}' (reflectivity traffic rate),
 #' '\code{mt}' ((cumulative) migration traffic),
 #' '\code{rt}' ((cumulative) reflectivity traffic),
-#' `\code{ff}`, (height-averaged speed)
-#' `\code{dd}`, (height-averaged direction)
-#' `\code{u}`, (height-averaged u-component of speed),
-#' `\code{v}`, (height-averaged v-component of speed).
+#' '\code{ff}' (height-averaged speed)
+#' '\code{dd}' (height-averaged direction)
+#' '\code{u}' (height-averaged u-component of speed),
+#' '\code{v}' (height-averaged v-component of speed).
 #' @param ylim y-axis plot range, numeric atomic vector of length 2.
 #' @param xlab A title for the x-axis.
 #' @param ylab A title for the y-axis.

--- a/R/ppi.R
+++ b/R/ppi.R
@@ -21,27 +21,27 @@
 #'  \item{\code{data}}{an object of class \link[sp]{SpatialGridDataFrame}
 #'    containing the georeferenced data. Commonly available parameters are:
 #'     \describe{
-#'      \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor [dBZ]}
-#'      \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor [dBZ]}
-#'      \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity [m/s]. Radial
+#'      \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor (dBZ)}
+#'      \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor (dBZ)}
+#'      \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity (m/s). Radial
 #'        velocities towards the radar are negative, while radial velocities
 #'        away from the radar are positive}
-#'      \item{"\code{RHOHV}"}{Correlation coefficient [unitless]. Correlation
+#'      \item{"\code{RHOHV}"}{Correlation coefficient (unitless). Correlation
 #'        between vertically polarized and horizontally polarized reflectivity
 #'        factor}
-#'      \item{"\code{PHIDP}"}{Differential phase [degrees]}
-#'      \item{"\code{ZDR}"}{(Logged) differential reflectivity [dB]}
+#'      \item{"\code{PHIDP}"}{Differential phase (degrees)}
+#'      \item{"\code{ZDR}"}{(Logged) differential reflectivity (dB)}
 #'        }
 #'  }
 #'  \item{\code{geo}}{geographic data, a list with:
 #'     \describe{
-#'      \item{\code{lat}}{latitude of the radar [decimal degrees]}
-#'      \item{\code{lon}}{longitude of the radar [decimal degrees]}
+#'      \item{\code{lat}}{latitude of the radar (decimal degrees)}
+#'      \item{\code{lon}}{longitude of the radar (decimal degrees)}
 #'      \item{\code{height}}{height of the radar
-#'        antenna [meters above sea level]}
-#'      \item{\code{elangle}}{radar beam elevation [degrees]}
-#'      \item{\code{rscale}}{range bin size [m]}
-#'      \item{\code{ascale}}{azimuth bin size [deg]}
+#'        antenna (meters above sea level)}
+#'      \item{\code{elangle}}{radar beam elevation (degrees)}
+#'      \item{\code{rscale}}{range bin size (m)}
+#'      \item{\code{ascale}}{azimuth bin size (deg)}
 #'     }
 #'     The \code{geo} element of a 'scan' object is a copy of the \code{geo}
 #'     element of its parent scan or scan parameter.

--- a/R/pvol.R
+++ b/R/pvol.R
@@ -14,16 +14,16 @@
 #' An object of class \code{pvol} is a list containing:
 #' \describe{
 #'  \item{\code{radar}}{character string with the radar identifier}
-#'  \item{\code{datetime}}{nominal time of the volume [UTC]}
+#'  \item{\code{datetime}}{nominal time of the volume (UTC)}
 #'  \item{\code{scans}}{a list with scan objects of class 'scan'}
 #'  \item{\code{attributes}}{list with the volume's \code{\\what},
 #'    \code{\\where} and \code{\\how} attributes}
 #'  \item{\code{geo}}{geographic data, a list with:
 #'   \describe{
-#'      \item{\code{lat}}{latitude of the radar [decimal degrees]}
-#'      \item{\code{lon}}{longitude of the radar [decimal degrees]}
+#'      \item{\code{lat}}{latitude of the radar (decimal degrees)}
+#'      \item{\code{lon}}{longitude of the radar (decimal degrees)}
 #'      \item{\code{height}}{height of the radar
-#'        antenna [meters above sea level]}
+#'        antenna (meters above sea level)}
 #'   }
 #'  }
 #' }

--- a/R/read_pvolfile.R
+++ b/R/read_pvolfile.R
@@ -32,16 +32,16 @@
 #' \href{https://github.com/adokter/vol2bird/blob/master/doc/OPERA2014_O4_ODIM_H5-v2.2.pdf}{ODIM specification}.
 #' Commonly available parameters are:
 #' \describe{
-#'  \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor [dBZ]}
-#'  \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor [dBZ]}
-#'  \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity [m/s]. Radial
+#'  \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor (dBZ)}
+#'  \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor (dBZ)}
+#'  \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity (m/s). Radial
 #'    velocities towards the radar are negative, while radial velocities away
 #'    from the radar are positive}
-#'  \item{"\code{RHOHV}"}{Correlation coefficient [unitless]. Correlation
+#'  \item{"\code{RHOHV}"}{Correlation coefficient (unitless). Correlation
 #'    between vertically polarized and horizontally polarized reflectivity
 #'    factor}
-#'  \item{"\code{PHIDP}"}{Differential phase [degrees]}
-#'  \item{"\code{ZDR}"}{(Logged) differential reflectivity [dB]}
+#'  \item{"\code{PHIDP}"}{Differential phase (degrees)}
+#'  \item{"\code{ZDR}"}{(Logged) differential reflectivity (dB)}
 #' }
 #'
 #' @examples

--- a/R/scan.R
+++ b/R/scan.R
@@ -15,19 +15,19 @@
 #' \describe{
 #'  \item{\code{radar}}{character string with the radar identifier}
 #'  \item{\code{datetime}}{nominal time of the volume to which this
-#'    scan belongs [UTC]}
+#'    scan belongs (UTC)}
 #'  \item{\code{params}}{a list with scan parameters}
 #'  \item{\code{attributes}}{list with the scan's \code{\\what},
 #'    \code{\\where} and \code{\\how} attributes}
 #'  \item{\code{geo}}{geographic data, a list with:
 #'     \describe{
-#'      \item{\code{lat}}{latitude of the radar [decimal degrees]}
-#'      \item{\code{lon}}{longitude of the radar [decimal degrees]}
+#'      \item{\code{lat}}{latitude of the radar (decimal degrees)}
+#'      \item{\code{lon}}{longitude of the radar (decimal degrees)}
 #'      \item{\code{height}}{height of the radar
-#'        antenna [meters above sea level]}
-#'      \item{\code{elangle}}{radar beam elevation [degrees]}
-#'      \item{\code{rscale}}{range bin size [m]}
-#'      \item{\code{ascale}}{azimuth bin size [deg]}
+#'        antenna (meters above sea level)}
+#'      \item{\code{elangle}}{radar beam elevation (degrees)}
+#'      \item{\code{rscale}}{range bin size (m)}
+#'      \item{\code{ascale}}{azimuth bin size (deg)}
 #'     }
 #'     The \code{geo} element of a \code{scan} object is a copy of the
 #'     \code{geo} element of its parent polar volume of class \code{pvol}.

--- a/R/vp.R
+++ b/R/vp.R
@@ -28,18 +28,18 @@
 #'  \item{\strong{\code{datetime}}}{the nominal time of the profile}
 #'  \item{\strong{\code{data}}}{the profile data, a list containing:
 #'    \describe{
-#'        \item{\code{height}}{height above mean sea level [m]. Alt. bin from height to height+interval)}
-#'        \item{\code{u}}{speed component west to east [m/s]}
-#'        \item{\code{v}}{speed component north to south [m/s]}
-#'        \item{\code{w}}{vertical speed (unreliable!) [m/s]}
-#'        \item{\code{ff}}{horizontal speed [m/s]}
-#'        \item{\code{dd}}{direction [degrees, clockwise from north]}
-#'        \item{\code{sd_vvp}}{VVP radial velocity standard deviation [m/s]}
-#'        \item{\code{gap}}{Angular data gap detected [T/F]}
-#'        \item{\code{dbz}}{Animal reflectivity factor [dBZ]}
-#'        \item{\code{eta}}{Animal reflectivity [cm^2/km^3]}
-#'        \item{\code{dens}}{Animal density [animals/km^3]}
-#'        \item{\code{DBZH}}{Total reflectivity factor (bio+meteo scattering) [dBZ]}
+#'        \item{\code{height}}{height above mean sea level (m). Alt. bin from height to height+interval)}
+#'        \item{\code{u}}{speed component west to east (m/s)}
+#'        \item{\code{v}}{speed component north to south (m/s)}
+#'        \item{\code{w}}{vertical speed (unreliable!) (m/s)}
+#'        \item{\code{ff}}{horizontal speed (m/s)}
+#'        \item{\code{dd}}{direction (degrees, clockwise from north)}
+#'        \item{\code{sd_vvp}}{VVP radial velocity standard deviation (m/s)}
+#'        \item{\code{gap}}{Angular data gap detected (T/F)}
+#'        \item{\code{dbz}}{Animal reflectivity factor (dBZ)}
+#'        \item{\code{eta}}{Animal reflectivity (cm^2/km^3)}
+#'        \item{\code{dens}}{Animal density (animals/km^3)}
+#'        \item{\code{DBZH}}{Total reflectivity factor (bio+meteo scattering) (dBZ)}
 #'        \item{\code{n}}{number of points VVPvelocity analysis (u,v,w,ff,dd)}
 #'        \item{\code{n_all}}{number of points VVP st.dev. estimate (sd_vvp)}
 #'        \item{\code{n_dbz}}{number of points density estimate (dbz,eta,dens)}

--- a/man/apply_mistnet.Rd
+++ b/man/apply_mistnet.Rd
@@ -59,7 +59,7 @@ it can estimate a segmentation mask that identifies pixels with weather
 that should be removed when interested only in biological data.
 
 MistNet will calculate three class probabilities (from 0 to 1, with 1 corresponding
-to a 100\\% probability) as additional scan parameters to the polar volume:
+to a 100\% probability) as additional scan parameters to the polar volume:
 \describe{
 \item{"\code{BACKGROUND}"}{class probability that no signal was detected above the noise level of the radar}
 \item{"\code{WEATHER}"}{class probability that weather was detected}

--- a/man/apply_mistnet.Rd
+++ b/man/apply_mistnet.Rd
@@ -59,7 +59,7 @@ it can estimate a segmentation mask that identifies pixels with weather
 that should be removed when interested only in biological data.
 
 MistNet will calculate three class probabilities (from 0 to 1, with 1 corresponding
-to a 100\% probability) as additional scan parameters to the polar volume:
+to a 100\\% probability) as additional scan parameters to the polar volume:
 \describe{
 \item{"\code{BACKGROUND}"}{class probability that no signal was detected above the noise level of the radar}
 \item{"\code{WEATHER}"}{class probability that weather was detected}
@@ -121,10 +121,10 @@ file.remove("~/KBGM_example")
 \references{
 Please also cite this publication when using MistNet:
 \itemize{
-  \item Lin T-Y, Winner K, Bernstein G, Mittal A, Dokter AM, Horten KG,
-  Nilsson C, Van Doren B, Farnsworth A, La Sorte FA, Maji S, Sheldon D (2019)
-  MistNet: Measuring historical bird migration in the US using archived
-  weather radar data and convolutional neural networks. Methods in Ecology
-  and Evolution 10: 1908– 1922. \url{https://doi.org/10.1111/2041-210X.13280}
+\item Lin T-Y, Winner K, Bernstein G, Mittal A, Dokter AM, Horten KG,
+Nilsson C, Van Doren B, Farnsworth A, La Sorte FA, Maji S, Sheldon D (2019)
+MistNet: Measuring historical bird migration in the US using archived
+weather radar data and convolutional neural networks. Methods in Ecology
+and Evolution 10: 1908– 1922. \url{https://doi.org/10.1111/2041-210X.13280}
 }
 }

--- a/man/beam_profile.Rd
+++ b/man/beam_profile.Rd
@@ -38,7 +38,7 @@ angle between the half-power (-3 dB) points of the main lobe}
 }
 \value{
 numeric vector. Normalized radiated energy at each of the specified
-  heights.
+heights.
 }
 \description{
 Calculate for a set of beam elevations elev
@@ -46,12 +46,12 @@ the altitudinal normalized distribution of radiated energy by those beams.
 }
 \details{
 Beam profile is calculated using \link{beam_height} and
-  \link{beam_width}. Returns a beam profile as a function of height relative
-  to ground level.
+\link{beam_width}. Returns a beam profile as a function of height relative
+to ground level.
 
-  Returns the normalized altitudinal pattern of radiated energy as a function
-  of altitude at a given distance from the radar, assuming the beams are
-  emitted at antenna level.
+Returns the normalized altitudinal pattern of radiated energy as a function
+of altitude at a given distance from the radar, assuming the beams are
+emitted at antenna level.
 }
 \examples{
 # plot the beam profile, for a 0.5 degree elevation beam at 50 km distance from the radar:

--- a/man/beam_profile_overlap.Rd
+++ b/man/beam_profile_overlap.Rd
@@ -28,22 +28,28 @@ beam_profile_overlap(
 
 \item{elev}{numeric vector. Beam elevation(s) in degrees.}
 
-\item{distance}{the distance(s) from the radar along sea level (down range) for which to calculate the overlap in m.}
+\item{distance}{the distance(s) from the radar along sea level (down range)
+for which to calculate the overlap in m.}
 
 \item{antenna}{radar antenna height. If missing taken from \code{vp}}
 
 \item{zlim}{altitude range in meter, given as a numeric vector of length two.}
 
-\item{noise_floor}{The system noise floor in dBZ. The total system noise expressed as the reflectivity factor
-it would represent at a distance \code{noise_floor_ref_range} from the radar. NOT YET IMPLEMENTED}
+\item{noise_floor}{The system noise floor in dBZ. The total system noise
+expressed as the reflectivity factor it would represent at a distance
+\code{noise_floor_ref_range} from the radar. NOT YET IMPLEMENTED}
 
-\item{noise_floor_ref_range}{the reference distance from the radar at which \code{noise_floor} is expressed. NOT YET IMPLEMENTED}
+\item{noise_floor_ref_range}{the reference distance from the radar at which
+\code{noise_floor} is expressed. NOT YET IMPLEMENTED}
 
-\item{steps}{number of integration steps over altitude range zlim, defining altitude grid size used for numeric integrations}
+\item{steps}{number of integration steps over altitude range zlim, defining
+altitude grid size used for numeric integrations}
 
-\item{quantity}{profile quantity to use for the altitude distribution, one of 'dens' or 'eta'.}
+\item{quantity}{profile quantity to use for the altitude distribution, one of
+'dens' or 'eta'.}
 
-\item{normalize}{Whether to normalize the radiation coverage pattern over the altitude range specified by zlim}
+\item{normalize}{Whether to normalize the radiation coverage pattern over the
+altitude range specified by zlim}
 
 \item{beam_angle}{numeric. Beam opening angle in degrees, typically the
 angle between the half-power (-3 dB) points of the main lobe}
@@ -60,32 +66,39 @@ angle between the half-power (-3 dB) points of the main lobe}
 A data.frame with columns distance and overlap.
 }
 \description{
-Calculates the distribution overlap between a vertical profile ('vp')
-and the vertical radiation profile of a set of emitted radar beams
-at various elevation angles as given by \link{beam_profile}.
+Calculates the distribution overlap between a vertical profile ('vp') and the
+vertical radiation profile of a set of emitted radar beams at various
+elevation angles as given by \link{beam_profile}.
 }
 \details{
-This function also calculates the \code{overlap} quantity in the output of \link{integrate_to_ppi}.
+This function also calculates the \code{overlap} quantity in the output of
+\link{integrate_to_ppi}.
 
-Overlap is calculated as the  \href{https://en.wikipedia.org/wiki/Bhattacharyya_distance}{Bhattacharyya coefficient}
-(i.e. distribution overlap) between the (normalized) vertical profile vp and the (normalized)
-radiation coverage pattern as calculated by \link{beam_profile}.
+Overlap is calculated as the \href{https://en.wikipedia.org/wiki/Bhattacharyya_distance}{Bhattacharyya coefficient} (i.e.
+distribution overlap) between the (normalized) vertical profile vp and the
+(normalized) radiation coverage pattern as calculated by
+\link{beam_profile}.
 
-The current implementation does not (yet) take into account the system noise floor when calculating
-the overlap.
+The current implementation does not (yet) take into account the system
+noise floor when calculating the overlap.
 
-In the ODIM data model the attribute \code{/how/NEZ} or \code{/how/NEZH} specifies the system noise floor
-(the Noise Equivalent Z or noise equivalent reflectivity factor. the H refers to the horizontal channel
-of a dual-polarization radar).
-In addition, the attribute \code{/how/LOG} gives "security distance above mean noise level (dB) threshold value".
-This is equivalent to the log receiver signal-to-noise ratio, i.e. the dB above the noise floor for the signal processor
-to report a valid reflectivity value. We recommend using \code{NEZH}+\code{LOG} for \code{noise_floor}, as this
-is the effective noise floor of the system below which no data will be reported by the radar signal processor.
+In the ODIM data model the attribute \code{/how/NEZ} or \code{/how/NEZH}
+specifies the system noise floor (the Noise Equivalent Z or noise
+equivalent reflectivity factor. the H refers to the horizontal channel of a
+dual-polarization radar). In addition, the attribute \code{/how/LOG} gives
+"security distance above mean noise level (dB) threshold value". This is
+equivalent to the log receiver signal-to-noise ratio, i.e. the dB above the
+noise floor for the signal processor to report a valid reflectivity value.
+We recommend using \code{NEZH}+\code{LOG} for \code{noise_floor}, as this
+is the effective noise floor of the system below which no data will be
+reported by the radar signal processor.
 
-Typical values are \code{NEZH} = -45 to -50 dBZ at 1 km from the radar. \code{LOG} is typically around 1 dB.
+Typical values are \code{NEZH} = -45 to -50 dBZ at 1 km from the radar.
+\code{LOG} is typically around 1 dB.
 
-Need to evaluate beam by beam the returned signal relative to a uniform beam filling of at least NEZH + LOG
-If returned signal is lower, the gate is below noise level.
+Need to evaluate beam by beam the returned signal relative to a uniform
+beam filling of at least NEZH + LOG If returned signal is lower, the gate
+is below noise level.
 }
 \examples{
 # locate example volume file:

--- a/man/beam_profile_overlap.Rd
+++ b/man/beam_profile_overlap.Rd
@@ -67,7 +67,7 @@ at various elevation angles as given by \link{beam_profile}.
 \details{
 This function also calculates the \code{overlap} quantity in the output of \link{integrate_to_ppi}.
 
- Overlap is calculated as the  [Bhattacharyya coefficient](https://en.wikipedia.org/wiki/Bhattacharyya_distance)
+Overlap is calculated as the  \href{https://en.wikipedia.org/wiki/Bhattacharyya_distance}{Bhattacharyya coefficient}
 (i.e. distribution overlap) between the (normalized) vertical profile vp and the (normalized)
 radiation coverage pattern as calculated by \link{beam_profile}.
 

--- a/man/bioRad-package.Rd
+++ b/man/bioRad-package.Rd
@@ -16,12 +16,12 @@ Extract, visualize and summarize aerial movements of birds and
 To get started, see:
 
 \itemize{
-  \item \href{https://doi.org/10.1111/ecog.04028}{Dokter et al. (2019)}: a
-  paper describing the package.
-  \item \href{https://adokter.github.io/bioRad/articles/bioRad.html}{bioRad
-  vignette}: an introduction to bioRad's main functionalities.
-  \item \href{https://adokter.github.io/bioRad/reference/index.html}{Function
-  reference}: an overview of all bioRad functions.
+\item \href{https://doi.org/10.1111/ecog.04028}{Dokter et al. (2019)}: a
+paper describing the package.
+\item \href{https://adokter.github.io/bioRad/articles/bioRad.html}{bioRad
+vignette}: an introduction to bioRad's main functionalities.
+\item \href{https://adokter.github.io/bioRad/reference/index.html}{Function
+reference}: an overview of all bioRad functions.
 }
 }
 \seealso{

--- a/man/calculate_param.Rd
+++ b/man/calculate_param.Rd
@@ -54,9 +54,9 @@ calculate_param(example_scan, DR = 10 * log10((ZDR + 1 - 2 * ZDR^0.5 * RHOHV) /
 }
 \references{
 \itemize{
-  \item Kilambi, A., Fabry, F., and Meunier, V., 2018. A simple and effective method
-  for separating meteorological from nonmeteorological targets using dual-polarization
-  data. Journal of Atmospheric and Oceanic Technology, 35, 1415–1424.
-  \url{https://doi.org/10.1175/JTECH-D-17-0175.1}
+\item Kilambi, A., Fabry, F., and Meunier, V., 2018. A simple and effective method
+for separating meteorological from nonmeteorological targets using dual-polarization
+data. Journal of Atmospheric and Oceanic Technology, 35, 1415–1424.
+\url{https://doi.org/10.1175/JTECH-D-17-0175.1}
 }
 }

--- a/man/calculate_vp.Rd
+++ b/man/calculate_vp.Rd
@@ -210,22 +210,22 @@ Dokter et al. (2011) is the main reference for the profiling algorithm
 please also cite Lin et al. 2019. When de-aliasing data, please also cite Haase et al. 2004.
 
 \itemize{
-  \item Adriaan M. Dokter, Felix Liechti,
-  Herbert Stark, Laurent Delobbe, Pierre Tabary, Iwan Holleman, 2011.
-  Bird migration flight altitudes studied by a network of
-  operational weather radars,
-  Journal of the Royal Society Interface 8 (54), pp. 30--43.
-  \url{https://doi.org/10.1098/rsif.2010.0116}
-  \item Haase, G. and Landelius, T., 2004. Dealiasing of Doppler radar
-  velocities using a torus mapping. Journal of Atmospheric and Oceanic
-  Technology, 21(10), pp.1566--1573.
-  \url{https://doi.org/10.1175/1520-0426(2004)021<1566:DODRVU>2.0.CO;2}
-  \item Tsung-Yu Lin, Kevin Winner, Garrett Bernstein, Abhay Mittal, Adriaan M. Dokter
-  Kyle G. Horton, Cecilia Nilsson, Benjamin M. Van Doren, Andrew Farnsworth
-  Frank A. La Sorte, Subhransu Maji, Daniel Sheldon, 2019.
-  MistNet: Measuring historical bird migration in the US
-  using archived weather radar data and convolutional neural networks
-  Methods in Ecology and Evolution 10 (11), pp. 1908--22.
-  \url{https://doi.org/10.1111/2041-210X.13280}
+\item Adriaan M. Dokter, Felix Liechti,
+Herbert Stark, Laurent Delobbe, Pierre Tabary, Iwan Holleman, 2011.
+Bird migration flight altitudes studied by a network of
+operational weather radars,
+Journal of the Royal Society Interface 8 (54), pp. 30--43.
+\url{https://doi.org/10.1098/rsif.2010.0116}
+\item Haase, G. and Landelius, T., 2004. Dealiasing of Doppler radar
+velocities using a torus mapping. Journal of Atmospheric and Oceanic
+Technology, 21(10), pp.1566--1573.
+\url{https://doi.org/10.1175/1520-0426(2004)021<1566:DODRVU>2.0.CO;2}
+\item Tsung-Yu Lin, Kevin Winner, Garrett Bernstein, Abhay Mittal, Adriaan M. Dokter
+Kyle G. Horton, Cecilia Nilsson, Benjamin M. Van Doren, Andrew Farnsworth
+Frank A. La Sorte, Subhransu Maji, Daniel Sheldon, 2019.
+MistNet: Measuring historical bird migration in the US
+using archived weather radar data and convolutional neural networks
+Methods in Ecology and Evolution 10 (11), pp. 1908--22.
+\url{https://doi.org/10.1111/2041-210X.13280}
 }
 }

--- a/man/check_date_format.Rd
+++ b/man/check_date_format.Rd
@@ -15,7 +15,7 @@ check_date_format(date, format)
 }
 \value{
 NULL. Will stop and show error message if date does not have correct
-  date format.
+date format.
 }
 \description{
 Check if character date is in specific format

--- a/man/check_radar_codes.Rd
+++ b/man/check_radar_codes.Rd
@@ -12,7 +12,7 @@ check_radar_codes(radars)
 }
 \value{
 NULL. Will stop and show error message if at least one of the
-  provided radar codes is not exactly 5 characters.
+provided radar codes is not exactly 5 characters.
 }
 \description{
 Check if radar codes are exactly 5 characters

--- a/man/get_quantity.Rd
+++ b/man/get_quantity.Rd
@@ -20,22 +20,22 @@ get_quantity(x, quantity)
 
 \item{quantity}{A profile quantity, one of:
 \itemize{
- \item{\code{"height"}}{}
- \item{\code{"u"}}{}
- \item{\code{"v"}}{}
- \item{\code{"w"}}{}
- \item{\code{"ff"}}{}
- \item{\code{"dd"}}{}
- \item{\code{"sd_vvp"}}{}
- \item{\code{"gap"}}{}
- \item{\code{"dbz"}}{}
- \item{\code{"eta"}}{}
- \item{\code{"dens"}}{}
- \item{\code{"DBZH"}}{}
- \item{\code{"n"}}{}
- \item{\code{"n_all"}}{}
- \item{\code{"n_dbz"}}{}
- \item{\code{"n_dbz_all"}}{}
+\item{\code{"height"}}{}
+\item{\code{"u"}}{}
+\item{\code{"v"}}{}
+\item{\code{"w"}}{}
+\item{\code{"ff"}}{}
+\item{\code{"dd"}}{}
+\item{\code{"sd_vvp"}}{}
+\item{\code{"gap"}}{}
+\item{\code{"dbz"}}{}
+\item{\code{"eta"}}{}
+\item{\code{"dens"}}{}
+\item{\code{"DBZH"}}{}
+\item{\code{"n"}}{}
+\item{\code{"n_all"}}{}
+\item{\code{"n_dbz"}}{}
+\item{\code{"n_dbz_all"}}{}
 }}
 }
 \value{

--- a/man/integrate_profile.Rd
+++ b/man/integrate_profile.Rd
@@ -62,22 +62,22 @@ weighted by density.
 The function generates a specially classed data frame with the following
 quantities:
 \describe{
-   \item{\code{datetime}}{POSIXct date of each profile in UTC}
-   \item{\code{vid}}{Vertically Integrated Density in individuals/km^2.
-      \code{vid} is a surface density, whereas \code{dens} in \code{vp}
-      objects is a volume density.}
-   \item{\code{vir}}{Vertically Integrated Reflectivity in cm^2/km^2}
-   \item{\code{mtr}}{Migration Traffic Rate in individuals/km/h}
-   \item{\code{rtr}}{Reflectivity Traffic Rate in cm^2/km/h}
-   \item{\code{mt}}{Migration Traffic in individuals/km, cumulated from
-      the start of the time series up to \code{datetime}}
-   \item{\code{rt}}{Reflectivity Traffic in cm^2/km, cumulated from
-      the start of the time series up to \code{datetime}}
-   \item{\code{ff}}{Horizontal ground speed in m/s}
-   \item{\code{dd}}{Horizontal ground speed direction in degrees}
-   \item{\code{u}}{Ground speed component west to east in m/s}
-   \item{\code{v}}{Ground speed component north to south in m/s}
-   \item{\code{height}}{Mean flight height (height weighted by eta) in m above sea level}
+\item{\code{datetime}}{POSIXct date of each profile in UTC}
+\item{\code{vid}}{Vertically Integrated Density in individuals/km^2.
+\code{vid} is a surface density, whereas \code{dens} in \code{vp}
+objects is a volume density.}
+\item{\code{vir}}{Vertically Integrated Reflectivity in cm^2/km^2}
+\item{\code{mtr}}{Migration Traffic Rate in individuals/km/h}
+\item{\code{rtr}}{Reflectivity Traffic Rate in cm^2/km/h}
+\item{\code{mt}}{Migration Traffic in individuals/km, cumulated from
+the start of the time series up to \code{datetime}}
+\item{\code{rt}}{Reflectivity Traffic in cm^2/km, cumulated from
+the start of the time series up to \code{datetime}}
+\item{\code{ff}}{Horizontal ground speed in m/s}
+\item{\code{dd}}{Horizontal ground speed direction in degrees}
+\item{\code{u}}{Ground speed component west to east in m/s}
+\item{\code{v}}{Ground speed component north to south in m/s}
+\item{\code{height}}{Mean flight height (height weighted by eta) in m above sea level}
 }
 Vertically integrated density and reflectivity are related according to
 \eqn{vid=vir/rcs(x)}, with \link{rcs} the assumed radar cross section per

--- a/man/integrate_to_ppi.Rd
+++ b/man/integrate_to_ppi.Rd
@@ -189,13 +189,13 @@ plot(my_ppi, param = "VID", zlim = c(0, 200))
 }
 \references{
 \itemize{
-  \item Kranstauber B, Bouten W, Leijnse H, Wijers B, Verlinden L,
-  Shamoun-Baranes J, Dokter AM (2020) High-Resolution Spatial Distribution of
-  Bird Movements Estimated from a Weather Radar Network. Remote Sensing 12 (4), 635.
-  \url{https://doi.org/10.3390/rs12040635}
-  \item Buler JJ & Diehl RH (2009) Quantifying bird density during migratory
-  stopover using weather surveillance radar. IEEE Transactions on Geoscience
-  and Remote Sensing 47: 2741-2751.
-  \url{https://doi.org/10.1109/TGRS.2009.2014463}
+\item Kranstauber B, Bouten W, Leijnse H, Wijers B, Verlinden L,
+Shamoun-Baranes J, Dokter AM (2020) High-Resolution Spatial Distribution of
+Bird Movements Estimated from a Weather Radar Network. Remote Sensing 12 (4), 635.
+\url{https://doi.org/10.3390/rs12040635}
+\item Buler JJ & Diehl RH (2009) Quantifying bird density during migratory
+stopover using weather surveillance radar. IEEE Transactions on Geoscience
+and Remote Sensing 47: 2741-2751.
+\url{https://doi.org/10.1109/TGRS.2009.2014463}
 }
 }

--- a/man/map.Rd
+++ b/man/map.Rd
@@ -75,15 +75,15 @@ layer map using \link[ggmap]{ggmap}.
 Available scan parameters for mapping can by printed to screen by
 \code{summary(x)}. Commonly available parameters are:
 \describe{
-\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor \link{dBZ}}
-\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor \link{dBZ}}
-\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity \link{m/s}. Radial
+\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor (dBZ)}
+\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor (dBZ)}
+\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity (m/s). Radial
 velocities towards the radar are negative, while radial velocities away
 from the radar are positive}
-\item{"\code{RHOHV}"}{Correlation coefficient \link{unitless}. Correlation
+\item{"\code{RHOHV}"}{Correlation coefficient (unitless) Correlation
 between vertically polarized and horizontally polarized reflectivity factor}
-\item{"\code{PHIDP}"}{Differential phase \link{degrees}}
-\item{"\code{ZDR}"}{(Logged) differential reflectivity \link{dB}}
+\item{"\code{PHIDP}"}{Differential phase (degrees)}
+\item{"\code{ZDR}"}{(Logged) differential reflectivity (dB)}
 }
 The scan parameters are named according to the OPERA data information
 model (ODIM), see Table 16 in the

--- a/man/map.Rd
+++ b/man/map.Rd
@@ -75,15 +75,15 @@ layer map using \link[ggmap]{ggmap}.
 Available scan parameters for mapping can by printed to screen by
 \code{summary(x)}. Commonly available parameters are:
 \describe{
- \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor [dBZ]}
- \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor [dBZ]}
- \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity [m/s]. Radial
- velocities towards the radar are negative, while radial velocities away
- from the radar are positive}
- \item{"\code{RHOHV}"}{Correlation coefficient [unitless]. Correlation
- between vertically polarized and horizontally polarized reflectivity factor}
- \item{"\code{PHIDP}"}{Differential phase [degrees]}
- \item{"\code{ZDR}"}{(Logged) differential reflectivity [dB]}
+\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor \link{dBZ}}
+\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor \link{dBZ}}
+\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity \link{m/s}. Radial
+velocities towards the radar are negative, while radial velocities away
+from the radar are positive}
+\item{"\code{RHOHV}"}{Correlation coefficient \link{unitless}. Correlation
+between vertically polarized and horizontally polarized reflectivity factor}
+\item{"\code{PHIDP}"}{Differential phase \link{degrees}}
+\item{"\code{ZDR}"}{(Logged) differential reflectivity \link{dB}}
 }
 The scan parameters are named according to the OPERA data information
 model (ODIM), see Table 16 in the

--- a/man/match_filenames.Rd
+++ b/man/match_filenames.Rd
@@ -14,7 +14,7 @@ filenames should comply.}
 }
 \value{
 character vector. Subset of filenames from the file_list that comply
-  to the provided regular expressions in regex_list.
+to the provided regular expressions in regex_list.
 }
 \description{
 Match a set of regular expressions to a list of files and return those

--- a/man/plot.ppi.Rd
+++ b/man/plot.ppi.Rd
@@ -40,15 +40,15 @@ using \link[ggplot2]{ggplot}
 Available scan paramaters for plotting can by printed to screen
 by \code{summary(x)}. Commonly available parameters are:
 \describe{
-\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor \link{dBZ}}
-\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor \link{dBZ}}
-\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity \link{m/s}. Radial
+\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor (dBZ)}
+\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor (dBZ)}
+\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity (m/s). Radial
 velocities towards the radar are negative, while radial velocities away
 from the radar are positive}
-\item{"\code{RHOHV}"}{Correlation coefficient \link{unitless}. Correlation
+\item{"\code{RHOHV}"}{Correlation coefficient (unitless). Correlation
 between vertically polarized and horizontally polarized reflectivity factor}
-\item{"\code{PHIDP}"}{Differential phase \link{degrees}}
-\item{"\code{ZDR}"}{(Logged) differential reflectivity \link{dB}}
+\item{"\code{PHIDP}"}{Differential phase (degrees)}
+\item{"\code{ZDR}"}{(Logged) differential reflectivity (dB)}
 }
 The scan parameters are named according to the OPERA data information
 model (ODIM), see Table 16 in the

--- a/man/plot.ppi.Rd
+++ b/man/plot.ppi.Rd
@@ -40,15 +40,15 @@ using \link[ggplot2]{ggplot}
 Available scan paramaters for plotting can by printed to screen
 by \code{summary(x)}. Commonly available parameters are:
 \describe{
- \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor [dBZ]}
- \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor [dBZ]}
- \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity [m/s]. Radial
- velocities towards the radar are negative, while radial velocities away
- from the radar are positive}
- \item{"\code{RHOHV}"}{Correlation coefficient [unitless]. Correlation
- between vertically polarized and horizontally polarized reflectivity factor}
- \item{"\code{PHIDP}"}{Differential phase [degrees]}
- \item{"\code{ZDR}"}{(Logged) differential reflectivity [dB]}
+\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor \link{dBZ}}
+\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor \link{dBZ}}
+\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity \link{m/s}. Radial
+velocities towards the radar are negative, while radial velocities away
+from the radar are positive}
+\item{"\code{RHOHV}"}{Correlation coefficient \link{unitless}. Correlation
+between vertically polarized and horizontally polarized reflectivity factor}
+\item{"\code{PHIDP}"}{Differential phase \link{degrees}}
+\item{"\code{ZDR}"}{(Logged) differential reflectivity \link{dB}}
 }
 The scan parameters are named according to the OPERA data information
 model (ODIM), see Table 16 in the

--- a/man/plot.scan.Rd
+++ b/man/plot.scan.Rd
@@ -37,16 +37,16 @@ see \link{ppi}
 Available scan parameters for plotting can by printed to screen
 by \code{summary(x)}. Commonly available parameters are:
 \describe{
- \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor [dBZ]}
- \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor [dBZ]}
- \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity [m/s]. Radial
-   velocities towards the radar are negative, while radial velocities away
-   from the radar are positive}
- \item{"\code{RHOHV}"}{Correlation coefficient [unitless]. Correlation
-   between vertically polarized and horizontally polarized
-   reflectivity factor}
- \item{"\code{PHIDP}"}{Differential phase [degrees]}
- \item{"\code{ZDR}"}{(Logged) differential reflectivity [dB]}
+\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor \link{dBZ}}
+\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor \link{dBZ}}
+\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity \link{m/s}. Radial
+velocities towards the radar are negative, while radial velocities away
+from the radar are positive}
+\item{"\code{RHOHV}"}{Correlation coefficient \link{unitless}. Correlation
+between vertically polarized and horizontally polarized
+reflectivity factor}
+\item{"\code{PHIDP}"}{Differential phase \link{degrees}}
+\item{"\code{ZDR}"}{(Logged) differential reflectivity \link{dB}}
 }
 The scan parameters are named according to the OPERA data information
 model (ODIM), see Table 16 in the

--- a/man/plot.scan.Rd
+++ b/man/plot.scan.Rd
@@ -37,16 +37,16 @@ see \link{ppi}
 Available scan parameters for plotting can by printed to screen
 by \code{summary(x)}. Commonly available parameters are:
 \describe{
-\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor \link{dBZ}}
-\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor \link{dBZ}}
-\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity \link{m/s}. Radial
+\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor (dBZ)}
+\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor (dBZ)}
+\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity (m/s). Radial
 velocities towards the radar are negative, while radial velocities away
 from the radar are positive}
-\item{"\code{RHOHV}"}{Correlation coefficient \link{unitless}. Correlation
+\item{"\code{RHOHV}"}{Correlation coefficient (unitless). Correlation
 between vertically polarized and horizontally polarized
 reflectivity factor}
-\item{"\code{PHIDP}"}{Differential phase \link{degrees}}
-\item{"\code{ZDR}"}{(Logged) differential reflectivity \link{dB}}
+\item{"\code{PHIDP}"}{Differential phase (degrees)}
+\item{"\code{ZDR}"}{(Logged) differential reflectivity (dB)}
 }
 The scan parameters are named according to the OPERA data information
 model (ODIM), see Table 16 in the

--- a/man/plot.vp.Rd
+++ b/man/plot.vp.Rd
@@ -22,11 +22,11 @@
 \item{quantity}{Character string with the quantity to plot. See
 \link[=summary.vp]{vp} for list of available quantities.
 \itemize{
- \item{Aerial density related:}{'\code{dens}', '\code{eta}', '\code{dbz}',
-   '\code{DBZH}' for density, reflectivity, reflectivity factor and total
-   reflectivity factor, respectively.}
- \item{Ground speed related:}{'\code{ff}','\code{dd}', for ground speed
-   and direction, respectively.}
+\item{Aerial density related:}{'\code{dens}', '\code{eta}', '\code{dbz}',
+'\code{DBZH}' for density, reflectivity, reflectivity factor and total
+reflectivity factor, respectively.}
+\item{Ground speed related:}{'\code{ff}','\code{dd}', for ground speed
+and direction, respectively.}
 }}
 
 \item{xlab}{A title for the x axis.}

--- a/man/plot.vpi.Rd
+++ b/man/plot.vpi.Rd
@@ -30,10 +30,10 @@ call to \link[bioRad]{integrate_profile}.}
 '\code{rtr}' (reflectivity traffic rate),
 '\code{mt}' ((cumulative) migration traffic),
 '\code{rt}' ((cumulative) reflectivity traffic),
-\verb{\code{ff}}, (height-averaged speed)
-\verb{\code{dd}}, (height-averaged direction)
-\verb{\code{u}}, (height-averaged u-component of speed),
-\verb{\code{v}}, (height-averaged v-component of speed).}
+'\code{ff}' (height-averaged speed)
+'\code{dd}' (height-averaged direction)
+'\code{u}' (height-averaged u-component of speed),
+'\code{v}' (height-averaged v-component of speed).}
 
 \item{xlab}{A title for the x-axis.}
 

--- a/man/plot.vpi.Rd
+++ b/man/plot.vpi.Rd
@@ -30,10 +30,10 @@ call to \link[bioRad]{integrate_profile}.}
 '\code{rtr}' (reflectivity traffic rate),
 '\code{mt}' ((cumulative) migration traffic),
 '\code{rt}' ((cumulative) reflectivity traffic),
-`\code{ff}`, (height-averaged speed)
-`\code{dd}`, (height-averaged direction)
-`\code{u}`, (height-averaged u-component of speed),
-`\code{v}`, (height-averaged v-component of speed).}
+\verb{\code{ff}}, (height-averaged speed)
+\verb{\code{dd}}, (height-averaged direction)
+\verb{\code{u}}, (height-averaged u-component of speed),
+\verb{\code{v}}, (height-averaged v-component of speed).}
 
 \item{xlab}{A title for the x-axis.}
 
@@ -66,24 +66,24 @@ Plot an object of class \code{vpi}.
 The integrated profiles can be visualized in various related quantities, as specified by
 argument \code{quantity}:
 \describe{
- \item{"\code{vid}"}{Vertically Integrated Density, i.e. the aerial surface
-   density of individuals. This quantity is dependent on the assumed radar
-   cross section per individual (RCS)}
- \item{"\code{vir}"}{Vertically Integrated Reflectivity. This quantity is
-   independent of the value of individual's radar cross section}
- \item{"\code{mtr}"}{Migration Traffic Rate. This quantity is dependent on
-   the assumed radar cross section (RCS)}
- \item{"\code{rtr}"}{Reflectivity Traffic Rate. This quantity is independent
-   on the assumed radar cross section (RCS)}
- \item{"\code{mt}"}{Migration Traffic. This quantity is dependent on
-   the assumed radar cross section (RCS)}
- \item{"\code{rt}"}{Reflectivity Traffic. This quantity is independent
-   on the assumed radar cross section (RCS)}
- \item{\code{ff}}{Horizontal ground speed in m/s}
- \item{\code{dd}}{Horizontal ground speed direction in degrees}
- \item{\code{u}}{Ground speed component west to east in m/s}
- \item{\code{v}}{Ground speed component north to south in m/s}
- \item{\code{height}}{Mean flight height (height weighted by reflectivity eta) in m above sea level}
+\item{"\code{vid}"}{Vertically Integrated Density, i.e. the aerial surface
+density of individuals. This quantity is dependent on the assumed radar
+cross section per individual (RCS)}
+\item{"\code{vir}"}{Vertically Integrated Reflectivity. This quantity is
+independent of the value of individual's radar cross section}
+\item{"\code{mtr}"}{Migration Traffic Rate. This quantity is dependent on
+the assumed radar cross section (RCS)}
+\item{"\code{rtr}"}{Reflectivity Traffic Rate. This quantity is independent
+on the assumed radar cross section (RCS)}
+\item{"\code{mt}"}{Migration Traffic. This quantity is dependent on
+the assumed radar cross section (RCS)}
+\item{"\code{rt}"}{Reflectivity Traffic. This quantity is independent
+on the assumed radar cross section (RCS)}
+\item{\code{ff}}{Horizontal ground speed in m/s}
+\item{\code{dd}}{Horizontal ground speed direction in degrees}
+\item{\code{u}}{Ground speed component west to east in m/s}
+\item{\code{v}}{Ground speed component north to south in m/s}
+\item{\code{height}}{Mean flight height (height weighted by reflectivity eta) in m above sea level}
 }
 The height-averaged speed quantities (ff,dd,u,v) and height are weighted averages by reflectivity eta.
 }

--- a/man/plot.vpts.Rd
+++ b/man/plot.vpts.Rd
@@ -74,19 +74,19 @@ Plot a time series of vertical profiles  of class \code{vpts}.
 Profile can be visualized in three related quantities, as specified
 by argument \code{quantity}:
 \describe{
- \item{"\code{dens}"}{the aerial density of individuals. This quantity is
-   dependent on the assumed radar cross section (RCS) in the
-   \code{x$attributes$how$rcs_bird} attribute}
- \item{"\code{eta}"}{reflectivity. This quantity is independent of the
-   value of the \code{rcs_bird} attribute}
- \item{"\code{dbz}"}{reflectivity factor. This quantity is independent
-   of the value of the \code{rcs_bird} attribute, and corresponds to the
-   dBZ scale commonly used in weather radar meteorology. Bioscatter by birds
-   tends to occur at much higher reflectivity factors at S-band
-   than at C-band}
- \item{"\code{DBZH}"}{total reflectivity factor. This quantity equals the
-   reflectivity factor of all scatterers (biological and meteorological
-   scattering combined)}
+\item{"\code{dens}"}{the aerial density of individuals. This quantity is
+dependent on the assumed radar cross section (RCS) in the
+\code{x$attributes$how$rcs_bird} attribute}
+\item{"\code{eta}"}{reflectivity. This quantity is independent of the
+value of the \code{rcs_bird} attribute}
+\item{"\code{dbz}"}{reflectivity factor. This quantity is independent
+of the value of the \code{rcs_bird} attribute, and corresponds to the
+dBZ scale commonly used in weather radar meteorology. Bioscatter by birds
+tends to occur at much higher reflectivity factors at S-band
+than at C-band}
+\item{"\code{DBZH}"}{total reflectivity factor. This quantity equals the
+reflectivity factor of all scatterers (biological and meteorological
+scattering combined)}
 }
 In the speed barbs, each half flag represents 2.5 m/s, each full flag 5 m/s,
 each pennant (triangle) 25 m/s

--- a/man/rcs-set.Rd
+++ b/man/rcs-set.Rd
@@ -25,7 +25,7 @@ rcs(x) <- value
 }
 \description{
 Sets the assumed radar cross section in cm^2. This method also updates
-the migration densities in `x$data$dens`.
+the migration densities in \code{x$data$dens}.
 }
 \details{
 See also \link{rcs} for retrieving the radar cross section

--- a/man/read_pvolfile.Rd
+++ b/man/read_pvolfile.Rd
@@ -62,16 +62,16 @@ model (ODIM), see Table 16 in the
 \href{https://github.com/adokter/vol2bird/blob/master/doc/OPERA2014_O4_ODIM_H5-v2.2.pdf}{ODIM specification}.
 Commonly available parameters are:
 \describe{
- \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor [dBZ]}
- \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor [dBZ]}
- \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity [m/s]. Radial
-   velocities towards the radar are negative, while radial velocities away
-   from the radar are positive}
- \item{"\code{RHOHV}"}{Correlation coefficient [unitless]. Correlation
-   between vertically polarized and horizontally polarized reflectivity
-   factor}
- \item{"\code{PHIDP}"}{Differential phase [degrees]}
- \item{"\code{ZDR}"}{(Logged) differential reflectivity [dB]}
+\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor \link{dBZ}}
+\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor \link{dBZ}}
+\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity \link{m/s}. Radial
+velocities towards the radar are negative, while radial velocities away
+from the radar are positive}
+\item{"\code{RHOHV}"}{Correlation coefficient \link{unitless}. Correlation
+between vertically polarized and horizontally polarized reflectivity
+factor}
+\item{"\code{PHIDP}"}{Differential phase \link{degrees}}
+\item{"\code{ZDR}"}{(Logged) differential reflectivity \link{dB}}
 }
 }
 \examples{

--- a/man/read_pvolfile.Rd
+++ b/man/read_pvolfile.Rd
@@ -62,16 +62,16 @@ model (ODIM), see Table 16 in the
 \href{https://github.com/adokter/vol2bird/blob/master/doc/OPERA2014_O4_ODIM_H5-v2.2.pdf}{ODIM specification}.
 Commonly available parameters are:
 \describe{
-\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor \link{dBZ}}
-\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor \link{dBZ}}
-\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity \link{m/s}. Radial
+\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor (dBZ)}
+\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor (dBZ)}
+\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity (m/s). Radial
 velocities towards the radar are negative, while radial velocities away
 from the radar are positive}
-\item{"\code{RHOHV}"}{Correlation coefficient \link{unitless}. Correlation
+\item{"\code{RHOHV}"}{Correlation coefficient (unitless). Correlation
 between vertically polarized and horizontally polarized reflectivity
 factor}
-\item{"\code{PHIDP}"}{Differential phase \link{degrees}}
-\item{"\code{ZDR}"}{(Logged) differential reflectivity \link{dB}}
+\item{"\code{PHIDP}"}{Differential phase (degrees)}
+\item{"\code{ZDR}"}{(Logged) differential reflectivity (dB)}
 }
 }
 \examples{

--- a/man/select_vpfiles.Rd
+++ b/man/select_vpfiles.Rd
@@ -24,7 +24,7 @@ looked for.}
 }
 \value{
 Character vector of file paths that comply to the given date and
-  radar range.
+radar range.
 }
 \description{
 Create a list of vertical profile (\code{vp}) files from a local directory

--- a/man/summary.param.Rd
+++ b/man/summary.param.Rd
@@ -30,11 +30,11 @@ specific attributes:
 \describe{
 \item{\code{radar}}{character string with the radar identifier}
 \item{\code{datetime}}{nominal time of the volume to which this
-scan belongs \link{UTC}}
-\item{\code{lat}}{latitude of the radar \link{decimal degrees}}
-\item{\code{lon}}{longitude of the radar \link{decimal degrees}}
-\item{\code{height}}{height of the radar antenna \link{meters above sea level}}
-\item{\code{get_elevation_angles}}{radar beam elevation \link{degrees}}
+scan belongs (UTC)}
+\item{\code{lat}}{latitude of the radar (decimal degrees)}
+\item{\code{lon}}{longitude of the radar (decimal degrees)}
+\item{\code{height}}{height of the radar antenna (meters above sea level)}
+\item{\code{get_elevation_angles}}{radar beam elevation (degrees)}
 \item{\code{param}}{string with the name of the polar scan parameter}
 }
 Scan parameters are named according to the OPERA data information model
@@ -42,15 +42,15 @@ Scan parameters are named according to the OPERA data information model
 \href{https://github.com/adokter/vol2bird/blob/master/doc/OPERA2014_O4_ODIM_H5-v2.2.pdf}{ODIM specification}.
 Commonly available parameters are:
 \describe{
-\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor \link{dBZ}}
-\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity \link{m/s}. Radial
+\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor (dBZ)}
+\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity (m/s). Radial
 velocities towards the radar are negative, while radial velocities away
 from the radar are positive}
-\item{"\code{RHOHV}"}{Correlation coefficient \link{unitless}. Correlation
+\item{"\code{RHOHV}"}{Correlation coefficient (unitless). Correlation
 between vertically polarized and horizontally polarized
 reflectivity factor}
-\item{"\code{PHIDP}"}{Differential phase \link{degrees}}
-\item{"\code{ZDR}"}{(Logged) differential reflectivity \link{dB}}
+\item{"\code{PHIDP}"}{Differential phase (degrees)}
+\item{"\code{ZDR}"}{(Logged) differential reflectivity (dB)}
 }
 }
 \examples{

--- a/man/summary.param.Rd
+++ b/man/summary.param.Rd
@@ -28,29 +28,29 @@ associated R base functions.
 An object of class \code{scan} is a simple matrix, with the following
 specific attributes:
 \describe{
-   \item{\code{radar}}{character string with the radar identifier}
-   \item{\code{datetime}}{nominal time of the volume to which this
-     scan belongs [UTC]}
-   \item{\code{lat}}{latitude of the radar [decimal degrees]}
-   \item{\code{lon}}{longitude of the radar [decimal degrees]}
-   \item{\code{height}}{height of the radar antenna [meters above sea level]}
-   \item{\code{get_elevation_angles}}{radar beam elevation [degrees]}
-   \item{\code{param}}{string with the name of the polar scan parameter}
+\item{\code{radar}}{character string with the radar identifier}
+\item{\code{datetime}}{nominal time of the volume to which this
+scan belongs \link{UTC}}
+\item{\code{lat}}{latitude of the radar \link{decimal degrees}}
+\item{\code{lon}}{longitude of the radar \link{decimal degrees}}
+\item{\code{height}}{height of the radar antenna \link{meters above sea level}}
+\item{\code{get_elevation_angles}}{radar beam elevation \link{degrees}}
+\item{\code{param}}{string with the name of the polar scan parameter}
 }
 Scan parameters are named according to the OPERA data information model
 (ODIM), see Table 16 in the
 \href{https://github.com/adokter/vol2bird/blob/master/doc/OPERA2014_O4_ODIM_H5-v2.2.pdf}{ODIM specification}.
 Commonly available parameters are:
 \describe{
- \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor [dBZ]}
- \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity [m/s]. Radial
-   velocities towards the radar are negative, while radial velocities away
-   from the radar are positive}
- \item{"\code{RHOHV}"}{Correlation coefficient [unitless]. Correlation
-   between vertically polarized and horizontally polarized
-   reflectivity factor}
- \item{"\code{PHIDP}"}{Differential phase [degrees]}
- \item{"\code{ZDR}"}{(Logged) differential reflectivity [dB]}
+\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor \link{dBZ}}
+\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity \link{m/s}. Radial
+velocities towards the radar are negative, while radial velocities away
+from the radar are positive}
+\item{"\code{RHOHV}"}{Correlation coefficient \link{unitless}. Correlation
+between vertically polarized and horizontally polarized
+reflectivity factor}
+\item{"\code{PHIDP}"}{Differential phase \link{degrees}}
+\item{"\code{ZDR}"}{(Logged) differential reflectivity \link{dB}}
 }
 }
 \examples{

--- a/man/summary.ppi.Rd
+++ b/man/summary.ppi.Rd
@@ -36,34 +36,34 @@ producing projections of the radar data onto the earth's surface.
 
 An object of class \code{ppi} is a list containing:
 \describe{
- \item{\code{data}}{an object of class \link[sp]{SpatialGridDataFrame}
-   containing the georeferenced data. Commonly available parameters are:
-    \describe{
-     \item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor [dBZ]}
-     \item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor [dBZ]}
-     \item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity [m/s]. Radial
-       velocities towards the radar are negative, while radial velocities
-       away from the radar are positive}
-     \item{"\code{RHOHV}"}{Correlation coefficient [unitless]. Correlation
-       between vertically polarized and horizontally polarized reflectivity
-       factor}
-     \item{"\code{PHIDP}"}{Differential phase [degrees]}
-     \item{"\code{ZDR}"}{(Logged) differential reflectivity [dB]}
-       }
- }
- \item{\code{geo}}{geographic data, a list with:
-    \describe{
-     \item{\code{lat}}{latitude of the radar [decimal degrees]}
-     \item{\code{lon}}{longitude of the radar [decimal degrees]}
-     \item{\code{height}}{height of the radar
-       antenna [meters above sea level]}
-     \item{\code{elangle}}{radar beam elevation [degrees]}
-     \item{\code{rscale}}{range bin size [m]}
-     \item{\code{ascale}}{azimuth bin size [deg]}
-    }
-    The \code{geo} element of a 'scan' object is a copy of the \code{geo}
-    element of its parent scan or scan parameter.
-  }
+\item{\code{data}}{an object of class \link[sp]{SpatialGridDataFrame}
+containing the georeferenced data. Commonly available parameters are:
+\describe{
+\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor \link{dBZ}}
+\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor \link{dBZ}}
+\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity \link{m/s}. Radial
+velocities towards the radar are negative, while radial velocities
+away from the radar are positive}
+\item{"\code{RHOHV}"}{Correlation coefficient \link{unitless}. Correlation
+between vertically polarized and horizontally polarized reflectivity
+factor}
+\item{"\code{PHIDP}"}{Differential phase \link{degrees}}
+\item{"\code{ZDR}"}{(Logged) differential reflectivity \link{dB}}
+}
+}
+\item{\code{geo}}{geographic data, a list with:
+\describe{
+\item{\code{lat}}{latitude of the radar \link{decimal degrees}}
+\item{\code{lon}}{longitude of the radar \link{decimal degrees}}
+\item{\code{height}}{height of the radar
+antenna \link{meters above sea level}}
+\item{\code{elangle}}{radar beam elevation \link{degrees}}
+\item{\code{rscale}}{range bin size \link{m}}
+\item{\code{ascale}}{azimuth bin size \link{deg}}
+}
+The \code{geo} element of a 'scan' object is a copy of the \code{geo}
+element of its parent scan or scan parameter.
+}
 }
 }
 \examples{

--- a/man/summary.ppi.Rd
+++ b/man/summary.ppi.Rd
@@ -39,27 +39,27 @@ An object of class \code{ppi} is a list containing:
 \item{\code{data}}{an object of class \link[sp]{SpatialGridDataFrame}
 containing the georeferenced data. Commonly available parameters are:
 \describe{
-\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor \link{dBZ}}
-\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor \link{dBZ}}
-\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity \link{m/s}. Radial
+\item{"\code{DBZH}", "\code{DBZ}"}{(Logged) reflectivity factor (dBZ)}
+\item{"\code{TH}", "\code{T}"}{(Logged) uncorrected reflectivity factor (dBZ)}
+\item{"\code{VRADH}", "\code{VRAD}"}{Radial velocity (m/s). Radial
 velocities towards the radar are negative, while radial velocities
 away from the radar are positive}
-\item{"\code{RHOHV}"}{Correlation coefficient \link{unitless}. Correlation
+\item{"\code{RHOHV}"}{Correlation coefficient (unitless). Correlation
 between vertically polarized and horizontally polarized reflectivity
 factor}
-\item{"\code{PHIDP}"}{Differential phase \link{degrees}}
-\item{"\code{ZDR}"}{(Logged) differential reflectivity \link{dB}}
+\item{"\code{PHIDP}"}{Differential phase (degrees)}
+\item{"\code{ZDR}"}{(Logged) differential reflectivity (dB)}
 }
 }
 \item{\code{geo}}{geographic data, a list with:
 \describe{
-\item{\code{lat}}{latitude of the radar \link{decimal degrees}}
-\item{\code{lon}}{longitude of the radar \link{decimal degrees}}
+\item{\code{lat}}{latitude of the radar (decimal degrees)}
+\item{\code{lon}}{longitude of the radar (decimal degrees)}
 \item{\code{height}}{height of the radar
-antenna \link{meters above sea level}}
-\item{\code{elangle}}{radar beam elevation \link{degrees}}
-\item{\code{rscale}}{range bin size \link{m}}
-\item{\code{ascale}}{azimuth bin size \link{deg}}
+antenna (meters above sea level)}
+\item{\code{elangle}}{radar beam elevation (degrees)}
+\item{\code{rscale}}{range bin size (m)}
+\item{\code{ascale}}{azimuth bin size (deg)}
 }
 The \code{geo} element of a 'scan' object is a copy of the \code{geo}
 element of its parent scan or scan parameter.

--- a/man/summary.pvol.Rd
+++ b/man/summary.pvol.Rd
@@ -27,16 +27,16 @@ Class \code{pvol} for a polar volume, and its associated R base functions.
 An object of class \code{pvol} is a list containing:
 \describe{
 \item{\code{radar}}{character string with the radar identifier}
-\item{\code{datetime}}{nominal time of the volume \link{UTC}}
+\item{\code{datetime}}{nominal time of the volume (UTC)}
 \item{\code{scans}}{a list with scan objects of class 'scan'}
 \item{\code{attributes}}{list with the volume's \code{\\what},
 \code{\\where} and \code{\\how} attributes}
 \item{\code{geo}}{geographic data, a list with:
 \describe{
-\item{\code{lat}}{latitude of the radar \link{decimal degrees}}
-\item{\code{lon}}{longitude of the radar \link{decimal degrees}}
+\item{\code{lat}}{latitude of the radar (decimal degrees)}
+\item{\code{lon}}{longitude of the radar (decimal degrees)}
 \item{\code{height}}{height of the radar
-antenna \link{meters above sea level}}
+antenna (meters above sea level)}
 }
 }
 }

--- a/man/summary.pvol.Rd
+++ b/man/summary.pvol.Rd
@@ -26,19 +26,19 @@ Class \code{pvol} for a polar volume, and its associated R base functions.
 \details{
 An object of class \code{pvol} is a list containing:
 \describe{
- \item{\code{radar}}{character string with the radar identifier}
- \item{\code{datetime}}{nominal time of the volume [UTC]}
- \item{\code{scans}}{a list with scan objects of class 'scan'}
- \item{\code{attributes}}{list with the volume's \code{\\what},
-   \code{\\where} and \code{\\how} attributes}
- \item{\code{geo}}{geographic data, a list with:
-  \describe{
-     \item{\code{lat}}{latitude of the radar [decimal degrees]}
-     \item{\code{lon}}{longitude of the radar [decimal degrees]}
-     \item{\code{height}}{height of the radar
-       antenna [meters above sea level]}
-  }
- }
+\item{\code{radar}}{character string with the radar identifier}
+\item{\code{datetime}}{nominal time of the volume \link{UTC}}
+\item{\code{scans}}{a list with scan objects of class 'scan'}
+\item{\code{attributes}}{list with the volume's \code{\\what},
+\code{\\where} and \code{\\how} attributes}
+\item{\code{geo}}{geographic data, a list with:
+\describe{
+\item{\code{lat}}{latitude of the radar \link{decimal degrees}}
+\item{\code{lon}}{longitude of the radar \link{decimal degrees}}
+\item{\code{height}}{height of the radar
+antenna \link{meters above sea level}}
+}
+}
 }
 }
 \examples{

--- a/man/summary.scan.Rd
+++ b/man/summary.scan.Rd
@@ -33,19 +33,19 @@ A object of class \code{scan} is a list containing:
 \describe{
 \item{\code{radar}}{character string with the radar identifier}
 \item{\code{datetime}}{nominal time of the volume to which this
-scan belongs \link{UTC}}
+scan belongs (UTC)}
 \item{\code{params}}{a list with scan parameters}
 \item{\code{attributes}}{list with the scan's \code{\\what},
 \code{\\where} and \code{\\how} attributes}
 \item{\code{geo}}{geographic data, a list with:
 \describe{
-\item{\code{lat}}{latitude of the radar \link{decimal degrees}}
-\item{\code{lon}}{longitude of the radar \link{decimal degrees}}
+\item{\code{lat}}{latitude of the radar (decimal degrees)}
+\item{\code{lon}}{longitude of the radar (decimal degrees)}
 \item{\code{height}}{height of the radar
-antenna \link{meters above sea level}}
-\item{\code{elangle}}{radar beam elevation \link{degrees}}
-\item{\code{rscale}}{range bin size \link{m}}
-\item{\code{ascale}}{azimuth bin size \link{deg}}
+antenna (meters above sea level)}
+\item{\code{elangle}}{radar beam elevation (degrees)}
+\item{\code{rscale}}{range bin size (m)}
+\item{\code{ascale}}{azimuth bin size (deg)}
 }
 The \code{geo} element of a \code{scan} object is a copy of the
 \code{geo} element of its parent polar volume of class \code{pvol}.

--- a/man/summary.scan.Rd
+++ b/man/summary.scan.Rd
@@ -31,25 +31,25 @@ Class \code{scan} for a scan of a polar volume, and its associated R base functi
 \details{
 A object of class \code{scan} is a list containing:
 \describe{
- \item{\code{radar}}{character string with the radar identifier}
- \item{\code{datetime}}{nominal time of the volume to which this
-   scan belongs [UTC]}
- \item{\code{params}}{a list with scan parameters}
- \item{\code{attributes}}{list with the scan's \code{\\what},
-   \code{\\where} and \code{\\how} attributes}
- \item{\code{geo}}{geographic data, a list with:
-    \describe{
-     \item{\code{lat}}{latitude of the radar [decimal degrees]}
-     \item{\code{lon}}{longitude of the radar [decimal degrees]}
-     \item{\code{height}}{height of the radar
-       antenna [meters above sea level]}
-     \item{\code{elangle}}{radar beam elevation [degrees]}
-     \item{\code{rscale}}{range bin size [m]}
-     \item{\code{ascale}}{azimuth bin size [deg]}
-    }
-    The \code{geo} element of a \code{scan} object is a copy of the
-    \code{geo} element of its parent polar volume of class \code{pvol}.
-  }
+\item{\code{radar}}{character string with the radar identifier}
+\item{\code{datetime}}{nominal time of the volume to which this
+scan belongs \link{UTC}}
+\item{\code{params}}{a list with scan parameters}
+\item{\code{attributes}}{list with the scan's \code{\\what},
+\code{\\where} and \code{\\how} attributes}
+\item{\code{geo}}{geographic data, a list with:
+\describe{
+\item{\code{lat}}{latitude of the radar \link{decimal degrees}}
+\item{\code{lon}}{longitude of the radar \link{decimal degrees}}
+\item{\code{height}}{height of the radar
+antenna \link{meters above sea level}}
+\item{\code{elangle}}{radar beam elevation \link{degrees}}
+\item{\code{rscale}}{range bin size \link{m}}
+\item{\code{ascale}}{azimuth bin size \link{deg}}
+}
+The \code{geo} element of a \code{scan} object is a copy of the
+\code{geo} element of its parent polar volume of class \code{pvol}.
+}
 }
 }
 \examples{

--- a/man/summary.vp.Rd
+++ b/man/summary.vp.Rd
@@ -43,18 +43,18 @@ A \code{vp} object is a list containing
 \item{\strong{\code{datetime}}}{the nominal time of the profile}
 \item{\strong{\code{data}}}{the profile data, a list containing:
 \describe{
-\item{\code{height}}{height above mean sea level \link{m}. Alt. bin from height to height+interval)}
-\item{\code{u}}{speed component west to east \link{m/s}}
-\item{\code{v}}{speed component north to south \link{m/s}}
-\item{\code{w}}{vertical speed (unreliable!) \link{m/s}}
-\item{\code{ff}}{horizontal speed \link{m/s}}
-\item{\code{dd}}{direction \link{degrees, clockwise from north}}
-\item{\code{sd_vvp}}{VVP radial velocity standard deviation \link{m/s}}
-\item{\code{gap}}{Angular data gap detected \link{T/F}}
-\item{\code{dbz}}{Animal reflectivity factor \link{dBZ}}
-\item{\code{eta}}{Animal reflectivity \link{cm^2/km^3}}
-\item{\code{dens}}{Animal density \link{animals/km^3}}
-\item{\code{DBZH}}{Total reflectivity factor (bio+meteo scattering) \link{dBZ}}
+\item{\code{height}}{height above mean sea level (m). Alt. bin from height to height+interval)}
+\item{\code{u}}{speed component west to east (m/s)}
+\item{\code{v}}{speed component north to south (m/s)}
+\item{\code{w}}{vertical speed (unreliable!) (m/s)}
+\item{\code{ff}}{horizontal speed (m/s)}
+\item{\code{dd}}{direction (degrees, clockwise from north)}
+\item{\code{sd_vvp}}{VVP radial velocity standard deviation (m/s)}
+\item{\code{gap}}{Angular data gap detected (T/F)}
+\item{\code{dbz}}{Animal reflectivity factor (dBZ)}
+\item{\code{eta}}{Animal reflectivity (cm^2/km^3)}
+\item{\code{dens}}{Animal density (animals/km^3)}
+\item{\code{DBZH}}{Total reflectivity factor (bio+meteo scattering) (dBZ)}
 \item{\code{n}}{number of points VVPvelocity analysis (u,v,w,ff,dd)}
 \item{\code{n_all}}{number of points VVP st.dev. estimate (sd_vvp)}
 \item{\code{n_dbz}}{number of points density estimate (dbz,eta,dens)}

--- a/man/summary.vp.Rd
+++ b/man/summary.vp.Rd
@@ -39,46 +39,46 @@ Data contained in this class object should be accessed with the
 
 A \code{vp} object is a list containing
 \describe{
- \item{\strong{\code{radar}}}{the radar identifier}
- \item{\strong{\code{datetime}}}{the nominal time of the profile}
- \item{\strong{\code{data}}}{the profile data, a list containing:
-   \describe{
-       \item{\code{height}}{height above mean sea level [m]. Alt. bin from height to height+interval)}
-       \item{\code{u}}{speed component west to east [m/s]}
-       \item{\code{v}}{speed component north to south [m/s]}
-       \item{\code{w}}{vertical speed (unreliable!) [m/s]}
-       \item{\code{ff}}{horizontal speed [m/s]}
-       \item{\code{dd}}{direction [degrees, clockwise from north]}
-       \item{\code{sd_vvp}}{VVP radial velocity standard deviation [m/s]}
-       \item{\code{gap}}{Angular data gap detected [T/F]}
-       \item{\code{dbz}}{Animal reflectivity factor [dBZ]}
-       \item{\code{eta}}{Animal reflectivity [cm^2/km^3]}
-       \item{\code{dens}}{Animal density [animals/km^3]}
-       \item{\code{DBZH}}{Total reflectivity factor (bio+meteo scattering) [dBZ]}
-       \item{\code{n}}{number of points VVPvelocity analysis (u,v,w,ff,dd)}
-       \item{\code{n_all}}{number of points VVP st.dev. estimate (sd_vvp)}
-       \item{\code{n_dbz}}{number of points density estimate (dbz,eta,dens)}
-       \item{\code{n_dbz_all}}{number of points total reflectivity estimate (DBZH)}
-   }
- }
- \item{\strong{\code{attributes}}}{list with the profile's \code{\\what},
- \code{\\where} and \code{\\how} attributes}
+\item{\strong{\code{radar}}}{the radar identifier}
+\item{\strong{\code{datetime}}}{the nominal time of the profile}
+\item{\strong{\code{data}}}{the profile data, a list containing:
+\describe{
+\item{\code{height}}{height above mean sea level \link{m}. Alt. bin from height to height+interval)}
+\item{\code{u}}{speed component west to east \link{m/s}}
+\item{\code{v}}{speed component north to south \link{m/s}}
+\item{\code{w}}{vertical speed (unreliable!) \link{m/s}}
+\item{\code{ff}}{horizontal speed \link{m/s}}
+\item{\code{dd}}{direction \link{degrees, clockwise from north}}
+\item{\code{sd_vvp}}{VVP radial velocity standard deviation \link{m/s}}
+\item{\code{gap}}{Angular data gap detected \link{T/F}}
+\item{\code{dbz}}{Animal reflectivity factor \link{dBZ}}
+\item{\code{eta}}{Animal reflectivity \link{cm^2/km^3}}
+\item{\code{dens}}{Animal density \link{animals/km^3}}
+\item{\code{DBZH}}{Total reflectivity factor (bio+meteo scattering) \link{dBZ}}
+\item{\code{n}}{number of points VVPvelocity analysis (u,v,w,ff,dd)}
+\item{\code{n_all}}{number of points VVP st.dev. estimate (sd_vvp)}
+\item{\code{n_dbz}}{number of points density estimate (dbz,eta,dens)}
+\item{\code{n_dbz_all}}{number of points total reflectivity estimate (DBZH)}
+}
+}
+\item{\strong{\code{attributes}}}{list with the profile's \code{\\what},
+\code{\\where} and \code{\\how} attributes}
 }
 
 \subsection{Conventions}{
-  \itemize{
-    \item \code{NA} Maps to 'nodata' in the ODIM convention: value to denote areas void of data
-     (never radiated)
-    \item \code{NaN} Maps to 'undetect' in the ODIM convention: denote areas below the measurement
-    detection threshold (radiated but nothing detected). The value is also used when there are too
-    few datapoints to calculate a quantity.
-    \item \code{0} Maps to 0 in the ODIM convention: denote areas where the quantity has a measured
-     value of zero (radiated and value zero detected or inferred).
-  }
-  It depends on a radar's detection threshold or signal to noise ratio whether it safe to assume
-  an 'undetect' is equivalent to zero. When dealing with close range data only (within 35 km), it
-  is typically safe to assume aerial densities (dens) and reflectivities (eta) are in fact zero
-  in case of undetects.
+\itemize{
+\item \code{NA} Maps to 'nodata' in the ODIM convention: value to denote areas void of data
+(never radiated)
+\item \code{NaN} Maps to 'undetect' in the ODIM convention: denote areas below the measurement
+detection threshold (radiated but nothing detected). The value is also used when there are too
+few datapoints to calculate a quantity.
+\item \code{0} Maps to 0 in the ODIM convention: denote areas where the quantity has a measured
+value of zero (radiated and value zero detected or inferred).
+}
+It depends on a radar's detection threshold or signal to noise ratio whether it safe to assume
+an 'undetect' is equivalent to zero. When dealing with close range data only (within 35 km), it
+is typically safe to assume aerial densities (dens) and reflectivities (eta) are in fact zero
+in case of undetects.
 }
 }
 \examples{

--- a/man/summary.vpts.Rd
+++ b/man/summary.vpts.Rd
@@ -53,22 +53,22 @@ Data contained in this class object should be accessed with the
 
 An object of class \code{vpts} is a list containing
 \describe{
- \item{\code{radar}}{string containing the radar identifier}
- \item{\code{datetime}}{the \code{N} nominal times of the profiles (named \code{dates} in bioRad versions < 0.4.0)}
- \item{\code{height}}{the \code{M} heights of the layers in the profile}
- \item{\code{daterange}}{the minimum and maximum nominal time of the
-   profiles in the list}
- \item{\code{timesteps}}{time differences between the profiles. Element
-   \code{i} gives the time difference between profile \code{i} and
-   \code{i+1}}
- \item{\code{data}}{list of \code{N} by \code{M} matrices containing the
-   vertical profiles for each quantity. For a description of available
-   quantities, see the \code{data} element of the \code{vp} class in
-   \link[=summary.vp]{read_vpfiles}}
- \item{\code{attributes}}{profile attributes, copied from the first profile
-   contained in \code{x}}
- \item{\code{regular}}{logical indicating whether the time series is
-   regular or not}
+\item{\code{radar}}{string containing the radar identifier}
+\item{\code{datetime}}{the \code{N} nominal times of the profiles (named \code{dates} in bioRad versions < 0.4.0)}
+\item{\code{height}}{the \code{M} heights of the layers in the profile}
+\item{\code{daterange}}{the minimum and maximum nominal time of the
+profiles in the list}
+\item{\code{timesteps}}{time differences between the profiles. Element
+\code{i} gives the time difference between profile \code{i} and
+\code{i+1}}
+\item{\code{data}}{list of \code{N} by \code{M} matrices containing the
+vertical profiles for each quantity. For a description of available
+quantities, see the \code{data} element of the \code{vp} class in
+\link[=summary.vp]{read_vpfiles}}
+\item{\code{attributes}}{profile attributes, copied from the first profile
+contained in \code{x}}
+\item{\code{regular}}{logical indicating whether the time series is
+regular or not}
 }
 }
 \examples{


### PR DESCRIPTION
Part of #240 

Note, this just enables it + fixes some conversion errors (like avoiding square brackets since these turn into links). Most of the documentation is still regular Roxygen.