### PR TITLE
Simplify vpts_to_vp: only if vpts has single profile

### DIFF
--- a/R/vpts.R
+++ b/R/vpts.R
@@ -161,20 +161,7 @@ dim.vpts <- function(x) {
 #' vpts[-1:-10] # A vpts object with 10 less profiles
 `[.vpts` <- function(x, i) {
   stopifnot(inherits(x, "vpts"))
-  if (length(i) == 1) {
-    if (i > 0) {
-      return(vpts_to_vp(x, i))
-    } else {
-      if (dim(x)[2] == 2) {
-        if (i == -1) {
-          return(vpts_to_vp(x, 2))
-        }
-        if (i == -2) {
-          return(vpts_to_vp(x, 1))
-        }
-      }
-    }
-  }
+
   x$datetime <- x$datetime[i]
   x$daterange <- .POSIXct(c(min(x$datetime), max(x$datetime)), tz = "UTC")
   x$timesteps <- difftime(x$datetime[-1], x$datetime[-length(x$datetime)],
@@ -193,25 +180,29 @@ dim.vpts <- function(x) {
     }
   )
   names(x$data) <- quantity.names
+
+  # Convert to vp if only 1 profile
+  if(length(x$datetime) == 1) {
+    x <- vpts_to_vp(x)
+  }
+
   return(x)
 }
 
-#' Helper function to convert a vpts[i] to a vp object
+#' Helper function to convert a vpts[1] to a vp object
 #'
 #' @noRd
-vpts_to_vp <- function(x, i) {
+vpts_to_vp <- function(x) {
   stopifnot(inherits(x, "vpts"))
-  nvp <- dim(x)[2]
-  if (i < 1 || i > nvp) {
-    return(NA)
-  }
+  stopifnot(length(x$datetime) == 1)
+
   vpout <- list()
   vpout$radar <- x$radar
-  vpout$datetime <- x$datetime[i]
+  vpout$datetime <- x$datetime[1]
   vpout$data <- as.data.frame(lapply(
     names(x$data),
     function(y) {
-      x$data[y][[1]][, i]
+      x$data[y][[1]]
     }
   ))
   names(vpout$data) <- names(x$data)

--- a/tests/testthat/test-vpts.R
+++ b/tests/testthat/test-vpts.R
@@ -47,6 +47,7 @@ test_that("[.vpts subsets by profiles", {
 test_that("[.vpts returns a vp object for single selection", {
   expect_s3_class(vpts[10:20], "vpts")
   expect_s3_class(vpts[10], "vp") # Select 10th => 1 profile
+  expect_s3_class(vpts[-1:-1933], "vp") # Remove 1933 => 1 profile left
   vpts_of_2 <- vpts[1:2]
   expect_s3_class(vpts_of_2[-1], "vp") # Remove 1st => 1 profile left
   expect_s3_class(vpts_of_2[-2], "vp") # Remove 2nd => 1 profile left


### PR DESCRIPTION
Simplified code to only call helper function `vpts_to_vp()` for vpts that ends up with single profiles.

- This no longer returns NA if i is out of bounds (was only done in some cases I think)
- Allows `vpts[-1:-1933]` to return `vp` (see test)
- Should make it easier to update this code if we decide to deprecate vp class