### PR TITLE
Improve input checking of composite_ppi() and fix ylim bug

### DIFF
--- a/R/composite_ppi.R
+++ b/R/composite_ppi.R
@@ -67,15 +67,15 @@ composite_ppi <- function(x, param = "DBZH", nx = 100, ny = 100, xlim, ylim, res
   if (FALSE %in% sapply(x, is.ppi)) {
     stop("'composite' expects objects of class ppi only")
   }
-  if (!is.number(nx) && missing(res)) stop("'nx' should be an integer")
-  if (!is.number(ny) && missing(res)) stop("ny' should be an integer")
+  if (!is.count(nx) && missing(res)) stop("'nx' should be an integer")
+  if (!is.count(ny) && missing(res)) stop("'ny' should be an integer")
   if (!missing(xlim)) {
-    if (length(xlim) != 2 & !is.numeric(xlim)) stop("'xlim' should be an integer vector of length two")
-    if (is.na(xlim[1]) | is.na(xlim[2]) | xlim[1] > xlim[2]) stop("'xlim' should be a vector with two numeric values for upper and lower bound")
+    if (length(xlim) != 2 & !is.numeric(xlim)) stop("'xlim' should be a numeric vector of length two")
+    if (is.na(xlim[1]) | is.na(xlim[2]) | xlim[1] > xlim[2]) stop("'xlim' should be a vector with two numeric values for lower and upper bound respectively")
   }
   if (!missing(ylim)) {
-    if (length(ylim) != 2 & !is.numeric(ylim)) stop("'ylim' should be an integer vector of length two")
-    if (is.na(ylim[1]) | is.na(ylim[2]) | ylim[1] > ylim[2]) stop("'ylim' should be a vector with two numeric values for upper and lower bound")
+    if (length(ylim) != 2 & !is.numeric(ylim)) stop("'ylim' should be a numeric vector of length two")
+    if (is.na(ylim[1]) | is.na(ylim[2]) | ylim[1] > ylim[2]) stop("'ylim' should be a vector with two numeric values for lower and upper bound respectively")
   }
   if (!missing(res)) {
     assert_that(is.numeric(res))
@@ -96,7 +96,7 @@ composite_ppi <- function(x, param = "DBZH", nx = 100, ny = 100, xlim, ylim, res
   lons <- sapply(ppis, function(x) x$geo$bbox["lon", ])
   lats <- sapply(ppis, function(x) x$geo$bbox["lat", ])
   if(!missing(xlim)) lons <- xlim
-  if(!missing(ylim)) lat <- ylim
+  if(!missing(ylim)) lats <- ylim
   lons.radar <- sapply(ppis, function(x) x$geo$lon)
   lats.radar <- sapply(ppis, function(x) x$geo$lat)
   elangles <- sapply(ppis, function(x) x$geo$elangle)


### PR DESCRIPTION
There are a few integer/numeric inconsistencies in the input checking that I've fixed:

- `nx` and `ny` (output cols and rows) have to be (positive) integers, so should be checked with `is.count()` instead of `is.number()`.
- `xlim` and `ylim` correspond with latlon limits, so do not have to be integers necessarily.

Additionally `ylim` could be defined, but was never used.