### PR TITLE
Astart rstart

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `scan_to_spatial()` now creates points for cell centers (#430)
 
+* The package now account for `rstart` and `astart` from the odim specification. (#434)
+
 # bioRad 0.5.2
 
 This release is primarily a hotfix for R version 4.0 (#375). All issues included in this release can be found [here](https://github.com/adokter/bioRad/milestone/11?closed=1). New features and improvements include:

--- a/R/plot.scan.R
+++ b/R/plot.scan.R
@@ -76,9 +76,13 @@ plot.scan <- function(x, param, xlim = c(0, 100000),
   class(data) <- "matrix"
   # convert to points
   dimraster <- dim(data)
-  ascale <- c(x$attributes$where$nrays) / 360
-  rscale <- c(x$attributes$where$rscale)
-  data <- raster::as.data.frame(raster::flip(raster(t(data), ymn = 0, ymx = 360, xmn = 0, xmx = rscale * dimraster[1]), direction = "y"), xy = T)
+
+  rscale <- x$geo$rscale
+  ascale <- x$geo$ascale
+  rstart <- ifelse(is.null(x$geo$rstart), 0, x$geo$rstart)
+  astart <- ifelse(is.null(x$geo$astart), 0, x$geo$astart)
+
+  data <- raster::as.data.frame(raster::flip(raster(t(data), ymn = astart, ymx = astart + 360, xmn = rstart, xmx = rstart + rscale * dimraster[1]), direction = "y"), xy = T)
   # change the name from "layer" to the parameter names
   names(data) <- c("range", "azimuth", param)
 

--- a/R/read_pvolfile.R
+++ b/R/read_pvolfile.R
@@ -307,6 +307,10 @@ read_pvolfile_scan <- function(file, scan, param, radar, datetime, geo) {
   geo$elangle <- c(attribs.where$elangle)
   geo$rscale <- c(attribs.where$rscale)
   geo$ascale <- c(360 / attribs.where$nrays)
+  geo$astart <- attribs.how$astart
+  # odim stores ranges as Km in package ranges are until now in meters
+  geo$rstart <- attribs.where$rstart * 1000
+
 
   # read scan parameters
   quantities <- lapply(

--- a/R/scan.R
+++ b/R/scan.R
@@ -27,6 +27,8 @@
 #'   240 km range).
 #'   * `ascale`: Azimuth bin size for that scan in degrees (e.g. 1 degree * 360
 #'   rays equals full circle).
+#'   * `rstart`: The range where the first range gate starts in meters (note ODIM stores it as kilometers)
+#'   * `astart`: The start of the first ray.
 #'
 #' @seealso
 #' * [get_scan()]

--- a/R/scan_convert.R
+++ b/R/scan_convert.R
@@ -37,10 +37,13 @@ scan_to_spatial <- function(scan, lat, lon, k = 4 / 3, re = 6378, rp = 6357) {
   rscale <- scan$geo$rscale
   ascale <- scan$geo$ascale
   elev <- scan$geo$elangle
+  rstart <- ifelse(is.null(scan$geo$rstart), 0, scan$geo$rstart)
+  astart <- ifelse(is.null(scan$geo$astart), 0, scan$geo$astart)
+
 
   data <- data.frame(
-    azim = c(t(matrix(rep(seq(0, dim(scan)[3] - 1) * ascale + ascale / 2, dim(scan)[2]), nrow = dim(scan)[3]))),
-    range = rep(seq(1, dim(scan)[2]) * rscale, dim(scan)[3]) - rscale / 2
+    azim = astart + c(t(matrix(rep(seq(0, dim(scan)[3] - 1) * ascale + ascale / 2, dim(scan)[2]), nrow = dim(scan)[3]))),
+    range = rstart + rep(seq(1, dim(scan)[2]) * rscale, dim(scan)[3]) - rscale / 2
   )
   data$distance <- beam_distance(range = data$range, elev = elev, k = k, lat = lat, re = re, rp = rp)
   data$height <- scan$geo$height + beam_height(data$range, elev, k = k, lat = lat, re = re, rp = rp)
@@ -142,6 +145,9 @@ scan_to_raster <- function(scan, nx = 100, ny = 100, xlim, ylim, res = NA, param
 
   rscale <- scan$geo$rscale
   ascale <- scan$geo$ascale
+  rstart <- ifelse(is.null(scan$geo$rstart), 0, scan$geo$rstart)
+  astart <- ifelse(is.null(scan$geo$astart), 0, scan$geo$astart)
+
 
   nrang <- dim(scan)[2]
   nazim <- dim(scan)[3]
@@ -174,10 +180,14 @@ scan_to_raster <- function(scan, nx = 100, ny = 100, xlim, ylim, res = NA, param
   crds <- coordinates(spTransform(rasterToPoints(r, spatial = T), localCrs))
   # convert raster coordinates to polar indices
   polar_coords <- cartesian_to_polar(crds, elev = scan$geo$elangle, k = k, lat = lat, re = re, rp = rp)
-  index <- polar_to_index(polar_coords, rangebin = rscale, azimbin = ascale)
+  index <- polar_to_index(polar_coords, rangebin = rscale, azimbin = ascale, rangestart = rstart, azimstart = astart)
   # set indices outside the scan's matrix to NA
   index$row[index$row > nrang] <- NA
   index$col[index$col > nazim] <- NA
+  # rstart can result in locations outside of the radar scope close to the radar
+  index$row[index$row < 1] <- NA
+  stopifnot(all(index$col >= 1))
+
   # convert 2D index to 1D index
   index <- (index$col - 1) * nrang + index$row
 
@@ -237,6 +247,8 @@ scan_to_spdf <- function(scan, spdf, param, lat, lon, k = 4 / 3, re = 6378, rp =
 
   rscale <- scan$geo$rscale
   ascale <- scan$geo$ascale
+  rstart <- ifelse(is.null(scan$geo$rstart), 0, scan$geo$rstart)
+  astart <- ifelse(is.null(scan$geo$astart), 0, scan$geo$astart)
 
   nrang <- dim(scan)[2]
   nazim <- dim(scan)[3]
@@ -244,10 +256,13 @@ scan_to_spdf <- function(scan, spdf, param, lat, lon, k = 4 / 3, re = 6378, rp =
   crds <- coordinates(spdf)
   # convert raster coordinates to polar indices
   polar_coords <- cartesian_to_polar(crds, elev = scan$geo$elangle, k = k, lat = lat, re = re, rp = rp)
-  index <- polar_to_index(polar_coords, rangebin = rscale, azimbin = ascale)
+  index <- polar_to_index(polar_coords, rangebin = rscale, azimbin = ascale, rangestart = rstart, azimstart = astart)
   # set indices outside the scan's matrix to NA
   index$row[index$row > nrang] <- NA
   index$col[index$col > nazim] <- NA
+  # rstart can result in locations outside of the radar scope close to the radar
+  index$row[index$row < 1] <- NA
+  stopifnot(all(index$col >= 1))
   # convert 2D index to 1D index
   index <- (index$col - 1) * nrang + index$row
 

--- a/man/summary.scan.Rd
+++ b/man/summary.scan.Rd
@@ -49,6 +49,8 @@ attributes.
 240 km range).
 \item \code{ascale}: Azimuth bin size for that scan in degrees (e.g. 1 degree * 360
 rays equals full circle).
+\item \code{rstart}: The range where the first range gate starts in meters (note ODIM stores it as kilometers)
+\item \code{astart}: The start of the first ray.
 }
 }
 }


### PR DESCRIPTION
this fixes #434 I opted not to set `rstart` and `astart` to 0 in the `geo` object as I think when it is not set in the odim file it should be null and not 0. I directly multiply it when reading to keep in the package using the range  in meters and not mix it up with KM.

I think I applied the fixes in all places I found it relevant (searching where `ascale` , `rscale` and `polar_to_index` is used)

@adokter did I miss some place?