### PR TITLE
add radar name as column to integrate_profile output (#425)

### DIFF
--- a/R/integrate_profile.R
+++ b/R/integrate_profile.R
@@ -207,7 +207,7 @@ integrate_profile.vp <- function(x, alt_min = 0, alt_max = Inf, alpha = NA,
   rt <- NA
   # prepare output
   output <- data.frame(
-    datetime = x$datetime, mtr = mtr, vid = vid, vir = vir,
+    radar=x$radar, datetime = x$datetime, mtr = mtr, vid = vid, vir = vir,
     rtr = rtr, mt = mt, rt = rt, ff = ff, dd = dd, u = u,
     v = v, height = height
   )
@@ -316,7 +316,7 @@ integrate_profile.vpts <- function(x, alt_min = 0, alt_max = Inf,
   rt <- cumsum(dt * rtr)
   # prepare output
   output <- data.frame(
-    datetime = x$datetime, mtr = mtr, vid = vid, vir = vir,
+    radar = x$radar, datetime = x$datetime, mtr = mtr, vid = vid, vir = vir,
     rtr = rtr, mt = mt, rt = rt, ff = ff, dd = dd, u = u,
     v = v, height = height
   )


### PR DESCRIPTION
* add column with radar name to integrate_profile output
* changes the structure vpi class, however since this was a simple data.frame likely not a breaking change for most users.
* fixes issue #425 