### PR TITLE
use ground speed consistently

### DIFF
--- a/R/get_quantity.R
+++ b/R/get_quantity.R
@@ -10,8 +10,8 @@
 #' @param x A `vp`, list of `vp` or `vpts` object.
 #' @param quantity Character. A (case sensitive) profile quantity, one of:
 #'   * `height`: Height bin (lower bound) in m above sea level.
-#'   * `u`: Speed component west to east in m/s.
-#'   * `v`: Speed component south to north in m/s.
+#'   * `u`: Ground speed component west to east in m/s.
+#'   * `v`: Ground speed component south to north in m/s.
 #'   * `w`: Vertical speed (unreliable!) in m/s.
 #'   * `ff`: Horizontal speed in m/s.
 #'   * `dd`: Direction in degrees clockwise from north.
@@ -43,7 +43,7 @@
 #' # Extract the animal density (dens) quantity from a vp object
 #' get_quantity(example_vp, "dens")
 #'
-#' # Extract the horizontal speed (ff) quantity from a vpts object and show the
+#' # Extract the horizontal ground speed (ff) quantity from a vpts object and show the
 #' # first two datetimes
 #' get_quantity(example_vpts, "ff")[,1:2]
 get_quantity <- function(x, quantity) {

--- a/R/plot.vpi.R
+++ b/R/plot.vpi.R
@@ -11,10 +11,10 @@
 #' '\code{rtr}' (reflectivity traffic rate),
 #' '\code{mt}' ((cumulative) migration traffic),
 #' '\code{rt}' ((cumulative) reflectivity traffic),
-#' '\code{ff}' (height-averaged speed)
+#' '\code{ff}' (height-averaged ground speed)
 #' '\code{dd}' (height-averaged direction)
-#' '\code{u}' (height-averaged u-component of speed),
-#' '\code{v}' (height-averaged v-component of speed).
+#' '\code{u}' (height-averaged u-component of ground speed),
+#' '\code{v}' (height-averaged v-component of ground speed).
 #' @param ylim y-axis plot range, numeric atomic vector of length 2.
 #' @param xlab A title for the x-axis.
 #' @param ylab A title for the y-axis.
@@ -57,7 +57,7 @@
 #'  \item{\code{v}}{Ground speed component south to north in m/s}
 #'  \item{\code{height}}{Mean flight height (height weighted by reflectivity eta) in m above sea level}
 #' }
-#' The height-averaged speed quantities (ff,dd,u,v) and height are weighted averages by reflectivity eta.
+#' The height-averaged ground speed quantities (ff,dd,u,v) and height are weighted averages by reflectivity eta.
 #' @examples
 #' # vertically integrate a vpts object:
 #' vpi <- integrate_profile(example_vpts)

--- a/R/vp.R
+++ b/R/vp.R
@@ -20,11 +20,11 @@
 #' * `data`: A data.frame with the profile's quantities organized per height
 #' bin. Use [get_quantity()] to access these:
 #'   * `height`: Height bin (lower bound) in m above sea level.
-#'   * `u`: Speed component west to east in m/s.
-#'   * `v`: Speed component south to north in m/s.
+#'   * `u`: Ground speed component west to east in m/s.
+#'   * `v`: Ground speed component south to north in m/s.
 #'   * `w`: Vertical speed (unreliable!) in m/s.
-#'   * `ff`: Horizontal speed in m/s.
-#'   * `dd`: Direction in degrees clockwise from north.
+#'   * `ff`: Horizontal ground speed in m/s.
+#'   * `dd`: Ground speed direction in degrees clockwise from north.
 #'   * `sd_vvp`: VVP radial velocity standard deviation in m/s.
 #'   * `gap`: Angular data gap detected in T/F.
 #'   * `dbz`: Animal reflectivity factor in dBZ.

--- a/man/get_quantity.Rd
+++ b/man/get_quantity.Rd
@@ -22,8 +22,8 @@ get_quantity(x, quantity)
 \item{quantity}{Character. A (case sensitive) profile quantity, one of:
 \itemize{
 \item \code{height}: Height bin (lower bound) in m above sea level.
-\item \code{u}: Speed component west to east in m/s.
-\item \code{v}: Speed component south to north in m/s.
+\item \code{u}: Ground speed component west to east in m/s.
+\item \code{v}: Ground speed component south to north in m/s.
 \item \code{w}: Vertical speed (unreliable!) in m/s.
 \item \code{ff}: Horizontal speed in m/s.
 \item \code{dd}: Direction in degrees clockwise from north.
@@ -66,7 +66,7 @@ height bin. Values for \code{eta} are set to \code{0}, \code{dbz} to \code{-Inf}
 # Extract the animal density (dens) quantity from a vp object
 get_quantity(example_vp, "dens")
 
-# Extract the horizontal speed (ff) quantity from a vpts object and show the
+# Extract the horizontal ground speed (ff) quantity from a vpts object and show the
 # first two datetimes
 get_quantity(example_vpts, "ff")[,1:2]
 }

--- a/man/plot.vpi.Rd
+++ b/man/plot.vpi.Rd
@@ -30,10 +30,10 @@ call to \link[bioRad]{integrate_profile}.}
 '\code{rtr}' (reflectivity traffic rate),
 '\code{mt}' ((cumulative) migration traffic),
 '\code{rt}' ((cumulative) reflectivity traffic),
-'\code{ff}' (height-averaged speed)
+'\code{ff}' (height-averaged ground speed)
 '\code{dd}' (height-averaged direction)
-'\code{u}' (height-averaged u-component of speed),
-'\code{v}' (height-averaged v-component of speed).}
+'\code{u}' (height-averaged u-component of ground speed),
+'\code{v}' (height-averaged v-component of ground speed).}
 
 \item{xlab}{A title for the x-axis.}
 
@@ -85,7 +85,7 @@ on the assumed radar cross section (RCS)}
 \item{\code{v}}{Ground speed component south to north in m/s}
 \item{\code{height}}{Mean flight height (height weighted by reflectivity eta) in m above sea level}
 }
-The height-averaged speed quantities (ff,dd,u,v) and height are weighted averages by reflectivity eta.
+The height-averaged ground speed quantities (ff,dd,u,v) and height are weighted averages by reflectivity eta.
 }
 \examples{
 # vertically integrate a vpts object:

--- a/man/summary.vp.Rd
+++ b/man/summary.vp.Rd
@@ -42,11 +42,11 @@ containing:
 bin. Use \code{\link[=get_quantity]{get_quantity()}} to access these:
 \itemize{
 \item \code{height}: Height bin (lower bound) in m above sea level.
-\item \code{u}: Speed component west to east in m/s.
-\item \code{v}: Speed component south to north in m/s.
+\item \code{u}: Ground speed component west to east in m/s.
+\item \code{v}: Ground speed component south to north in m/s.
 \item \code{w}: Vertical speed (unreliable!) in m/s.
-\item \code{ff}: Horizontal speed in m/s.
-\item \code{dd}: Direction in degrees clockwise from north.
+\item \code{ff}: Horizontal ground speed in m/s.
+\item \code{dd}: Ground speed direction in degrees clockwise from north.
 \item \code{sd_vvp}: VVP radial velocity standard deviation in m/s.
 \item \code{gap}: Angular data gap detected in T/F.
 \item \code{dbz}: Animal reflectivity factor in dBZ.


### PR DESCRIPTION
When referring to speed quantities in documentation, make clear it is ground speed