### PR TITLE
hotfix check_night: adding subsetting to lat lon

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bioRad
 Title: Biological Analysis and Visualization of Weather Radar Data
-Version: 0.5.2.9494
+Version: 0.5.2.9499
 Description: Extract, visualize and summarize aerial movements of birds and
     insects from weather radar data. See <doi:10.1111/ecog.04028>
     for a software paper describing package and methodologies.

--- a/R/check_night.R
+++ b/R/check_night.R
@@ -66,8 +66,14 @@ check_night.default <- function(x, lon, lat, ..., tz = "UTC", elev = -0.268, off
   assert_that(length(offset)<=2)
   assert_that(is.numeric(lon))
   assert_that(is.numeric(lat))
+  assert_that(length(lat)==length(lon))
   #
   x <- as.POSIXct(x, tz = tz)
+  #
+  if(length(x)>1 & length(lon)==1){
+    lon=rep(lon,length(x)) # to accomodate lon subsetting below
+    lat=rep(lat,length(x)) # to accomodate lon subsetting below
+  }
   #
   elev_sunset = ifelse(length(elev) == 2,elev[1],elev)
   elev_sunrise = ifelse(length(elev) == 2,elev[2],elev)

--- a/R/check_night.R
+++ b/R/check_night.R
@@ -82,16 +82,16 @@ check_night.default <- function(x, lon, lat, ..., tz = "UTC", elev = -0.268, off
   tset_ordered = tset
   # sunrise -1 day
   idx <- which(x < tset  & trise > tset)
-  if(length(idx)>0) trise_ordered[idx] = sunrise(x[idx]-24*3600, lon, lat, tz = tz, elev = elev_sunrise)
+  if(length(idx)>0) trise_ordered[idx] = sunrise(x[idx]-24*3600, lon[idx], lat[idx], tz = tz, elev = elev_sunrise)
   # sunrise +1 day
   idx <- which(x > tset  & trise < tset)
-  if(length(idx)>0) trise_ordered[idx] = sunrise(x[idx]+24*3600, lon, lat, tz = tz, elev = elev_sunrise)
+  if(length(idx)>0) trise_ordered[idx] = sunrise(x[idx]+24*3600, lon[idx], lat[idx], tz = tz, elev = elev_sunrise)
   # sunset -1 day
   idx <- which(x < trise & trise < tset)
-  if(length(idx)>0) tset_ordered[idx] = sunset(x[idx]-24*3600, lon, lat, tz = tz, elev = elev_sunset)
+  if(length(idx)>0) tset_ordered[idx] = sunset(x[idx]-24*3600, lon[idx], lat[idx], tz = tz, elev = elev_sunset)
   # sunset +1 day
   idx <- which(x > trise & trise > tset)
-  if(length(idx)>0) tset_ordered[idx] = sunset(x[idx]+24*3600, lon, lat, tz = tz, elev = elev_sunset)
+  if(length(idx)>0) tset_ordered[idx] = sunset(x[idx]+24*3600, lon[idx], lat[idx], tz = tz, elev = elev_sunset)
   # store in original variable
   trise <- trise_ordered
   tset <- tset_ordered


### PR DESCRIPTION
fix for a bug that caused `check_night()` to throw this error occasionally
```
 Error in .balanceCrdsTimes(crdsmtx, dateTime) : 
  mismatch in number of coordinates and times 
```