### PR TITLE
allow use of vol2bird.sh as local_install

### DIFF
--- a/R/calculate_vp.R
+++ b/R/calculate_vp.R
@@ -66,7 +66,7 @@
 #'   scans at 0.5, 1.5, 2.5, 3.5 and 4.5 degrees. Specifying different elevation
 #'   angles may compromise segmentation results.
 #' @param local_install Character. Path to local vol2bird installation (e.g.
-#'   `your/vol2bird_install_directory/vol2bird/bin/vol2bird`).
+#'   `your/vol2bird_install_directory/vol2bird/bin/vol2bird.sh`).
 #' @param local_mistnet Character. Path to local MistNet segmentation model in
 #'   PyTorch format (e.g. `/your/path/mistnet_nexrad.pt`).
 #'
@@ -257,9 +257,10 @@ calculate_vp <- function(file, vpfile = "", pvolfile_out = "",
   if (file.access(mount, 2) == -1) {
     stop(glue("No write permission to `mount` directory: {mount}"))
   }
-  if ((missing(local_install) && !missing(local_mistnet)) || (!missing(local_install) && missing(local_mistnet))) {
+  if ((missing(local_install) && !missing(local_mistnet)) || (!missing(local_install) && missing(local_mistnet) && mistnet)){
     stop("To use local vol2bird and MistNet model, specify both `local_install` and `local_mistnet`.")
   }
+
   assert_that(is.numeric(mistnet_elevations))
   assert_that(length(mistnet_elevations) == 5)
   if (!.pkgenv$docker && missing(local_install)) {

--- a/R/nexrad_odim.R
+++ b/R/nexrad_odim.R
@@ -102,11 +102,14 @@ nexrad_to_odim_tempfile <- function(pvolfile, verbose = FALSE,
         ignore.stdout = !verbose
       )
     } else{
+      # check if we have vol2bird.sh or vol2bird
+      ext=paste0(".",strsplit(basename(local_install), split="\\.")[[1]][-1])
+      if(ext==".") ext=""
       if(dirname(local_install)=="."){
-        rsl2odim_path = "rsl2odim"  # when vol2bird and rls2odim are in the PATH
+        rsl2odim_path = paste0("rsl2odim",ext)  # when vol2bird and rls2odim are in the PATH
       }
       else{
-        rsl2odim_path = paste(dirname(local_install),"/rsl2odim",sep="")
+        rsl2odim_path = paste0(dirname(local_install),"/rsl2odim",ext)
       }
       result <- system(paste("bash -l -c \"", rsl2odim_path, pvolfile, pvol_tmp, "\""), ignore.stdout = !verbose)
     }


### PR DESCRIPTION
vol2bird and adokter/vol2birdinstall generate new script files `vol2bird.sh` and `rsl2odim.sh` which correctly set all library paths. We want to migrate users to using vol2bird.sh instead of vol2bird, and this fix allows specification of vol2bird.sh as a local install