### PR TITLE
Fix for #498 Infer conversion details if missing

### DIFF
--- a/R/write_pvolfile.R
+++ b/R/write_pvolfile.R
@@ -68,8 +68,8 @@ write_pvolfile <- function(pvol, file, overwrite = FALSE, infer_dtype = FALSE) {
 
         if (!isTRUE(int) | longint) {
           # Store as 32-bit floats instead
-          conv$offset <- floor(min(v, na.rm = TRUE) - 1)
-          conv$nodata <- ceiling(max(v, na.rm = TRUE))
+          conv$offset <- floor(min(v, na.rm = TRUE)) - 1
+          conv$nodata <- ceiling(max(v, na.rm = TRUE)) + 1 - conv$offset
           conv$dtype <- "H5T_IEEE_F32BE"
         }
       }

--- a/R/write_pvolfile.R
+++ b/R/write_pvolfile.R
@@ -39,8 +39,41 @@ write_pvolfile <- function(pvol, file, overwrite = FALSE, infer_dtype = FALSE) {
       h5createGroup(fid, paste0("dataset", i, "/data", j))
       data <- pvol$scans[[i]]$params[[j]]
       conv <- attributes(data)$conversion
+
       d <- data
       class(d) <- "matrix"
+
+      if (is.null(conv)) {
+        conv <- list()
+        longint <- FALSE
+        # Check if data can be stored directly as integers
+        # with a default nodata & undetect
+        v <- as.vector(data)
+        int <- all.equal(v, as.integer(v), na.rm = TRUE)
+        range_bits <- max(v, na.rm = TRUE) - min(v, na.rm = TRUE)
+        conv$gain <- 1
+        conv$undetect <- 0
+        if (isTRUE(int)) {
+          conv$offset <- min(v, na.rm = TRUE) - 1
+          if (range_bits <= 254) {
+            conv$nodata <- 255
+            conv$dtype <- "H5T_STD_U8BE"
+          } else if (range_bits > 254 & range_bits <= 65534) {
+            conv$nodata <- 65535
+            conv$dtype <- "H5T_STD_I16BE"
+          } else {
+            longint <- TRUE # for 16-bit+ integers just use float
+          }
+        }
+
+        if (!isTRUE(int) | longint) {
+          # Store as 32-bit floats instead
+          conv$offset <- floor(min(v, na.rm = TRUE) - 1)
+          conv$nodata <- ceiling(max(v, na.rm = TRUE))
+          conv$dtype <- "H5T_IEEE_F32BE"
+        }
+      }
+
       d <- (d - conv$offset) / conv$gain
       d <- replace(d, is.nan(data), conv$undetect) # Replace NaNs
       d <- replace(d, is.na(data) & !is.nan(data), conv$nodata)

--- a/tests/testthat/test-write_pvolfile.R
+++ b/tests/testthat/test-write_pvolfile.R
@@ -39,6 +39,8 @@ test_that("write_pvolfile() writes 8-bit integer if possible and conversion is m
                attributes(pvol$scans[[1]]$params$DBZH)$conversion)
   expect_equal(attributes(pvol_new$scans[[1]]$params$DBZH)$conversion$dtype,
                "H5T_STD_U8BE")
+  expect_equal(matrix(pvol_noconversion$scans[[1]]$params[['DBZH']]),
+               matrix(pvol_new$scans[[1]]$params[['DBZH']]))
 })
 
 test_that("write_pvolfile() writes 16-bit integer if possible and conversion is missing", {
@@ -52,6 +54,8 @@ test_that("write_pvolfile() writes 16-bit integer if possible and conversion is 
   expect_equal(conv$gain, 1)
   expect_equal(conv$nodata, 65535)
   expect_equal(conv$undetect, 0)
+  expect_equal(matrix(pvol_noconversion$scans[[1]]$params[['DBZH']]),
+               matrix(pvol_new$scans[[1]]$params[['DBZH']]))
 })
 
 test_that("write_pvolfile() writes float if values are not integers and conversion is missing", {
@@ -63,6 +67,8 @@ test_that("write_pvolfile() writes float if values are not integers and conversi
   expect_equal(conv$dtype, "H5T_IEEE_F32BE")
   expect_equal(conv$offset, -3005)
   expect_equal(conv$gain, 1)
-  expect_equal(conv$nodata, 5507)
+  expect_equal(conv$nodata, 8513)
   expect_equal(conv$undetect, 0)
+  expect_equal(matrix(pvol_noconversion$scans[[1]]$params[['DBZH']]),
+               matrix(pvol_new$scans[[1]]$params[['DBZH']]), tolerance = 1e-5)
 })


### PR DESCRIPTION
If `calculate_param()` causes conversion information to be missing, this will figure out how to write the data (see #498). If all values are  integers and can be stored as 8- or 16-bit integers (including a nodata and undetect value), it will be stored as such. If not, it will simply be stored directly as a 32-bit float, which should be more than sufficient.

@bart1 I think this should be an OK fix?