### PR TITLE
add single_pol flag

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,5 +61,5 @@ Suggests:
 LazyData: true
 Encoding: UTF-8
 VignetteBuilder: knitr
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 Roxygen: list(markdown = TRUE)

--- a/R/calculate_vp.R
+++ b/R/calculate_vp.R
@@ -34,10 +34,11 @@
 #' @param rcs Numeric. Radar cross section per bird to use, in cm^2.
 #' @param dual_pol Logical. When `TRUE`, uses dual-pol mode, in which
 #'   meteorological echoes are filtered using the correlation coefficient
-#'   `rho_hv`. When `FALSE`, uses single polarization mode based only on
-#'   reflectivity and radial velocity quantities.
+#'   threshold `rho_hv`.
 #' @param rho_hv Numeric. Lower threshold in correlation coefficient to use for
 #'   filtering meteorological scattering.
+#' @param single_pol Logical. When `TRUE`, uses precipitation filtering in single
+#' polarization mode based on reflectivity and radial velocity quantities.
 #' @param elev_min Numeric. Minimum elevation angle to include, in degrees.
 #' @param elev_max Numeric. Maximum elevation angle to include, in degrees.
 #' @param azim_min Numeric. Minimum azimuth to include, in degrees clockwise
@@ -188,8 +189,8 @@
 calculate_vp <- function(file, vpfile = "", pvolfile_out = "",
                          autoconf = FALSE, verbose = FALSE, warnings = TRUE,
                          mount, sd_vvp_threshold,
-                         rcs = 11, dual_pol = TRUE, rho_hv = 0.95, elev_min = 0,
-                         elev_max = 90, azim_min = 0, azim_max = 360,
+                         rcs = 11, dual_pol = TRUE, rho_hv = 0.95, single_pol = TRUE,
+                         elev_min = 0, elev_max = 90, azim_min = 0, azim_max = 360,
                          range_min = 5000, range_max = 35000, n_layer = 20,
                          h_layer = 200, dealias = TRUE,
                          nyquist_min = if (dealias) 5 else 25,
@@ -203,8 +204,8 @@ calculate_vp <- function(file, vpfile = "", pvolfile_out = "",
       vpfile = vpfile, pvolfile_out = pvolfile_out,
       autoconf = autoconf, verbose = verbose, warnings = warnings,
       mount = mount, sd_vvp_threshold = sd_vvp_threshold,
-      rcs = rcs, dual_pol = dual_pol, rho_hv = rho_hv, elev_min = elev_min,
-      elev_max = 90, azim_min = 0, azim_max = 360,
+      rcs = rcs, dual_pol = dual_pol, rho_hv = rho_hv, single_pol=single_pol,
+      elev_min = elev_min, elev_max = 90, azim_min = 0, azim_max = 360,
       range_min = range_min, range_max = range_max, n_layer = n_layer,
       h_layer = h_layer, dealias = dealias,
       nyquist_min = nyquist_min,
@@ -271,6 +272,7 @@ calculate_vp <- function(file, vpfile = "", pvolfile_out = "",
   assert_that(rcs > 0)
   assert_that(is.flag(dual_pol))
   assert_that(is.number(rho_hv))
+  assert_that(is.flag(single_pol))
   assert_that(
     rho_hv >= 0 & rho_hv <= 1,
     msg = "`rho_hv` must be a number between 0 and 1."

--- a/man/bind_into_vpts.Rd
+++ b/man/bind_into_vpts.Rd
@@ -40,18 +40,18 @@ of altitude layers, i.e. the maximum altitude
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{vp}: Bind multiple \code{vp} into a \code{vpts}.
+\item \code{bind_into_vpts(vp)}: Bind multiple \code{vp} into a \code{vpts}.
 If \code{vp} for multiple radars are provided, a list is returned containing
 a \code{vpts} for each radar.
 
-\item \code{list}: Bind multiple \code{vp} objects into a
+\item \code{bind_into_vpts(list)}: Bind multiple \code{vp} objects into a
 \code{vpts}. If data for multiple radars is provided, a list is returned
 containing a \code{vpts} for each radar.
 
-\item \code{vpts}: Bind multiple \code{vpts} into a single
+\item \code{bind_into_vpts(vpts)}: Bind multiple \code{vpts} into a single
 \code{vpts}. Requires the input \code{vpts} to be from the same radar.
-}}
 
+}}
 \examples{
 # load example time series of vertical profiles:
 data(example_vpts)

--- a/man/calculate_param.Rd
+++ b/man/calculate_param.Rd
@@ -31,13 +31,13 @@ clutter corrections (CCORH) to uncorrected reflectivity moments (TH), as in TH+C
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{pvol}: Calculate a new scan parameter for all scans in a polar volume.
+\item \code{calculate_param(pvol)}: Calculate a new scan parameter for all scans in a polar volume.
 
-\item \code{ppi}: Calculate a new parameter for a PPI.
+\item \code{calculate_param(ppi)}: Calculate a new parameter for a PPI.
 
-\item \code{scan}: Calculate a new scan parameter for a scan
+\item \code{calculate_param(scan)}: Calculate a new scan parameter for a scan
+
 }}
-
 \examples{
 # locate example volume file:
 pvolfile <- system.file("extdata", "volume.h5", package = "bioRad")

--- a/man/calculate_vp.Rd
+++ b/man/calculate_vp.Rd
@@ -16,6 +16,7 @@ calculate_vp(
   rcs = 11,
   dual_pol = TRUE,
   rho_hv = 0.95,
+  single_pol = TRUE,
   elev_min = 0,
   elev_max = 90,
   azim_min = 0,
@@ -71,11 +72,13 @@ C-band radars and 1 m/s for S-band radars.}
 
 \item{dual_pol}{Logical. When \code{TRUE}, uses dual-pol mode, in which
 meteorological echoes are filtered using the correlation coefficient
-\code{rho_hv}. When \code{FALSE}, uses single polarization mode based only on
-reflectivity and radial velocity quantities.}
+threshold \code{rho_hv}.}
 
 \item{rho_hv}{Numeric. Lower threshold in correlation coefficient to use for
 filtering meteorological scattering.}
+
+\item{single_pol}{Logical. When \code{TRUE}, uses precipitation filtering in single
+polarization mode based on reflectivity and radial velocity quantities.}
 
 \item{elev_min}{Numeric. Minimum elevation angle to include, in degrees.}
 

--- a/man/integrate_profile.Rd
+++ b/man/integrate_profile.Rd
@@ -203,15 +203,15 @@ ground speed directions vary with altitude.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{vp}: Vertically integrate a vertical profile.
+\item \code{integrate_profile(vp)}: Vertically integrate a vertical profile.
 
-\item \code{list}: Vertically integrate a list of
+\item \code{integrate_profile(list)}: Vertically integrate a list of
 vertical profiles.
 
-\item \code{vpts}: Vertically integrate a time series of
+\item \code{integrate_profile(vpts)}: Vertically integrate a time series of
 vertical profiles.
+
 }}
-
 \examples{
 # MTR for a single vertical profile
 integrate_profile(example_vp)

--- a/man/map.Rd
+++ b/man/map.Rd
@@ -91,9 +91,9 @@ model (ODIM), see Table 16 in the
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{ppi}: plot a 'ppi' object on a map
-}}
+\item \code{map(ppi)}: plot a 'ppi' object on a map
 
+}}
 \examples{
 # load an example scan:
 data(example_scan)

--- a/man/project_as_ppi.Rd
+++ b/man/project_as_ppi.Rd
@@ -79,12 +79,12 @@ The returned PPI is in Azimuthal Equidistant Projection.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{param}: Project as \code{ppi} for a single scan parameter.
+\item \code{project_as_ppi(param)}: Project as \code{ppi} for a single scan parameter.
 
-\item \code{scan}: Project multiple \code{ppi}'s for all scan
+\item \code{project_as_ppi(scan)}: Project multiple \code{ppi}'s for all scan
 parameters in a scan
-}}
 
+}}
 \examples{
 # load a polar scan example object:
 data(example_scan)


### PR DESCRIPTION
Adds `single_pol` argument to `calculate_vp()`. single_pol precipitation filtering used to be enabled at all times. Adding option to disable it and allow filtering by correlation coefficient only (by setting dual_pol=TRUE, single_pol=FALSE)