### PR TITLE
review dontrun blocks in examples (#528)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bioRad
 Title: Biological Analysis and Visualization of Weather Radar Data
-Version: 0.7.0.9582
+Version: 0.7.0.9597
 Description: Extract, visualize and summarize aerial movements of birds and
     insects from weather radar data. See <doi:10.1111/ecog.04028>
     for a software paper describing package and methodologies.

--- a/R/bind_into_vpts.R
+++ b/R/bind_into_vpts.R
@@ -156,10 +156,10 @@ bind_into_vpts.vpts <- function(..., attributes_from = 1) {
 #' @keywords internal
 #'
 #' @examples
-#' \dontrun{
-#' vps <- read_vpfiles(c("my/path/profile1.h5", "my/path/profile2.h5", ...))
+#' vpfile1 <- system.file("extdata", "profile.h5", package = "bioRad")
+#' vpfile2 <- vpfile1
+#' vps <- read_vpfiles(c(vpfile1,vpfile2))
 #' ts <- bind_into_vpts(vps)
-#' }
 vplist_to_vpts <- function(x, radar = NA) {
   stopifnot(inherits(x, "list"))
   # extract radar identifiers

--- a/R/calculate_vp.R
+++ b/R/calculate_vp.R
@@ -170,7 +170,6 @@
 #' (11), pp. 1908-22. \doi{10.1111/2041-210X.13280}
 #'
 #' @examples
-#' \dontrun{
 #' # Locate and read the polar volume example file
 #' pvolfile <- system.file("extdata", "volume.h5", package = "bioRad")
 #'
@@ -185,7 +184,6 @@
 #'
 #' # Clean up
 #' file.remove("~/volume.h5")
-#' }
 calculate_vp <- function(file, vpfile = "", pvolfile_out = "",
                          autoconf = FALSE, verbose = FALSE, warnings = TRUE,
                          mount, sd_vvp_threshold,

--- a/R/composite_ppi.R
+++ b/R/composite_ppi.R
@@ -62,7 +62,6 @@
 #' This function is a prototype and under active development
 #'
 #' @examples
-#' \dontrun{
 #' # Locate and read the polar volume example file
 #' pvolfile <- system.file("extdata", "volume.h5", package = "bioRad")
 #' pvol <- read_pvolfile(pvolfile)
@@ -73,7 +72,7 @@
 #' # Overlay the ppis, calculating the maximum value observed
 #' # across the available scans at each geographic location
 #' composite <- composite_ppi(ppis, method = "max")
-#'
+#' \dontrun{
 #' # Download basemap
 #' bm <- download_basemap(composite)
 #'

--- a/R/data.R
+++ b/R/data.R
@@ -14,13 +14,11 @@
 #' # Get summary info
 #' example_scan
 #'
-#' # example_scan was created with
-#' \dontrun{
-#' pvolfile <- system.file("extdata", "volume.h5", package = "bioRad")
-#' pvol <- read_pvolfile(pvolfile)
-#' example_scan <- pvol$scans[[1]]
-#' save(example_scan, file = "data/example_scan.rda")
-#' }
+#' ## example_scan was created with:
+#' # pvolfile <- system.file("extdata", "volume.h5", package = "bioRad")
+#' # pvol <- read_pvolfile(pvolfile)
+#' # example_scan <- pvol$scans[[1]]
+#' # save(example_scan, file = "data/example_scan.rda")
 "example_scan"
 
 #' Vertical profile (`vp`) example
@@ -39,12 +37,10 @@
 #' # Get summary info
 #' example_vp
 #'
-#' # example_vp was created with
-#' \dontrun{
-#' vpfile <- system.file("extdata", "profile.h5", package = "bioRad")
-#' example_vp <- read_vpfiles(vpfile)
-#' save(example_vp, file = "data/example_vp.rda")
-#' }
+#' ## example_vp was created with:
+#' # vpfile <- system.file("extdata", "profile.h5", package = "bioRad")
+#' # example_vp <- read_vpfiles(vpfile)
+#' # save(example_vp, file = "data/example_vp.rda")
 "example_vp"
 
 #' Time series of vertical profiles (`vpts`) example
@@ -63,16 +59,14 @@
 #' # Get summary info
 #' example_vpts
 #'
-#' # example_vpts was created with
-#' \dontrun{
-#' vptsfile <- system.file("extdata", "vpts.txt.zip", package = "bioRad")
-#' utils::unzip(vptsfile, exdir = (dirname(vptsfile)), junkpaths = TRUE)
-#' vptsfile <- substr(vptsfile, 1, nchar(vptsfile) - 4)
-#' example_vpts <- read_vpts(vptsfile, radar = "KBGM", wavelength = "S")
-#' rcs(example_vpts) <- 11
-#' sd_vvp_threshold(example_vpts) <- 2
-#' example_vpts$attributes$where$lat <- 42.2
-#' example_vpts$attributes$where$lon <- -75.98
-#' save(example_vpts, file = "data/example_vpts.rda", compress = "xz")
-#' }
+#' ## example_vpts was created with
+#' # vptsfile <- system.file("extdata", "vpts.txt.zip", package = "bioRad")
+#' # utils::unzip(vptsfile, exdir = (dirname(vptsfile)), junkpaths = TRUE)
+#' # vptsfile <- substr(vptsfile, 1, nchar(vptsfile) - 4)
+#' # example_vpts <- read_vpts(vptsfile, radar = "KBGM", wavelength = "S")
+#' # rcs(example_vpts) <- 11
+#' # sd_vvp_threshold(example_vpts) <- 2
+#' # example_vpts$attributes$where$lat <- 42.2
+#' # example_vpts$attributes$where$lon <- -75.98
+#' # save(example_vpts, file = "data/example_vpts.rda", compress = "xz")
 "example_vpts"

--- a/R/download_pvolfiles.R
+++ b/R/download_pvolfiles.R
@@ -19,14 +19,18 @@
 #'
 #' @examples
 #' \dontrun{
-#' dir.create("~/bioRad_tmp_files")
+#' create temporary directory
+#' temp_dir <- paste0(tempdir(),"/bioRad_tmp_files")
+#' dir.create(temp_dir)
 #' download_pvolfiles(
 #'   date_min = as.POSIXct("2016-10-02 20:00", tz = "UTC"),
 #'   date_max = as.POSIXct("2016-10-02 20:05", tz = "UTC"),
 #'   radar = "KBBX",
-#'   directory = "~/bioRad_tmp_files",
+#'   directory = temp_dir,
 #'   overwrite = TRUE
 #' )
+#' # Clean up
+#' unlink(temp_dir, recursive = T)
 #' }
 download_pvolfiles <- function(date_min, date_max, radar,
                                directory = ".", overwrite = FALSE,

--- a/R/download_vpfiles.R
+++ b/R/download_vpfiles.R
@@ -26,16 +26,17 @@
 #' # Will successfully download 2016-10 files, but show 404 error for
 #' # 2016-11 files, since these are not available.
 #' \dontrun{
-#' dir.create("~/bioRad_tmp_files")
+#' temp_dir <- paste0(tempdir(),"/bioRad_tmp_files")
+#' dir.create(temp_dir)
 #' download_vpfiles(
 #'   date_min = "2016-10-01",
 #'   date_max = "2016-11-30",
 #'   radars = c("bejab", "bewid"),
-#'   directory = "~/bioRad_tmp_files",
+#'   directory = temp_dir,
 #'   overwrite = TRUE
 #' )
 #' # Clean up
-#' unlink("~/bioRad_tmp_files", recursive = T)
+#' unlink(temp_dir, recursive = T)
 #' }
 download_vpfiles <- function(date_min, date_max, radars, directory = ".",
                              overwrite = FALSE) {

--- a/R/integrate_to_ppi.R
+++ b/R/integrate_to_ppi.R
@@ -110,7 +110,6 @@
 #' # 0-2000 cm^2/km^2 color scale
 #' plot(ppi, zlim = c(0, 2000))
 #'
-#' \dontrun{
 #' # Calculate the range-corrected ppi on finer 2000m x 2000m pixel raster
 #' ppi <- integrate_to_ppi(pvol, example_vp, res = 2000)
 #'
@@ -118,9 +117,11 @@
 #' # 0-200 birds/km^2 color scale
 #' plot(ppi, param = "VID", zlim = c(0, 200))
 #'
+#' \dontrun{
 #' # Download a basemap and map the ppi
 #' bm <- download_basemap(ppi)
 #' map(ppi, bm)
+#' }
 #'
 #' # The ppi can also be projected on a user-defined raster, as follows:
 #'
@@ -143,7 +144,6 @@
 #'   xlim = c(-50000, 50000), ylim = c(-50000, 50000)
 #' )
 #' plot(ppi, param = "VID", zlim = c(0, 200))
-#' }
 #' @references
 #' * Kranstauber B, Bouten W, Leijnse H, Wijers B, Verlinden L, Shamoun-Baranes
 #'   J, Dokter AM (2020) High-Resolution Spatial Distribution of Bird

--- a/R/plot.scan.R
+++ b/R/plot.scan.R
@@ -36,14 +36,13 @@
 #' @examples
 #' # Plot reflectivity
 #' plot(example_scan, param = "DBZH")
-#' \dontrun{
+#'
 #' # Change the range of reflectivities to plot, from -10 to 10 dBZ
 #' plot(example_scan, param = "DBZH", zlim = c(-10, 10))
 #'
 #' # Change the scale name, change the color palette to Viridis colors
 #' plot(example_scan, param = "DBZH", zlim = c(-10, 10)) +
 #'   viridis::scale_fill_viridis(name = "dBZ")
-#' }
 plot.scan <- function(x, param, xlim = c(0, 100000),
                       ylim = c(0, 360), zlim = c(-20, 20), na.value = "transparent", ...) {
   stopifnot(inherits(x, "scan"))

--- a/R/read_vpfiles.R
+++ b/R/read_vpfiles.R
@@ -100,11 +100,8 @@ read_vp <- function(file) {
 #' # load the file:
 #' read_vpfiles(vpfile)
 #'
-#' # load multiple files at once:
-#' \dontrun{
+#' # to load multiple files at once:
 #' # read_vpfiles(c("my/path/profile1.h5", "my/path/profile2.h5", ...))
-#' }
-#'
 read_vpfiles <- function(files) {
   if (length(files) == 1) {
     return(read_vp(files))

--- a/R/scan_convert.R
+++ b/R/scan_convert.R
@@ -77,6 +77,7 @@ scan_to_spatial <- function(scan, lat, lon, k = 4 / 3, re = 6378, rp = 6357) {
 #' the same raster pixel, the last added pixel is given (see [rasterize][raster::rasterize] for details).
 #' @export
 #' @examples
+#' \dontrun{
 #' # default projects full extent on 100x100 pixel raster:
 #' scan_to_raster(example_scan)
 #'
@@ -86,6 +87,7 @@ scan_to_spatial <- function(scan, lat, lon, k = 4 / 3, re = 6378, rp = 6357) {
 #' # using a template raster
 #' template_raster <- raster::raster(raster::extent(12, 13, 56, 58), crs = sp::CRS("+proj=longlat"))
 #' scan_to_raster(example_scan, raster = template_raster)
+#' }
 scan_to_raster <- function(scan, nx = 100, ny = 100, xlim, ylim, res = NA, param, raster = NA, lat, lon, crs = NA, k = 4 / 3, re = 6378, rp = 6357) {
   if (!is.scan(scan)) stop("'scan' should be an object of class scan")
   if (get_elevation_angles(scan) == 90) stop("georeferencing of 90 degree birdbath scan not supported")

--- a/R/write_pvolfile.R
+++ b/R/write_pvolfile.R
@@ -20,9 +20,10 @@
 #'
 #' # write the file:
 #' pvolfile_out <- paste0(tempdir(),"pvolfile_out.h5")
-#' \dontrun{
 #' write_pvolfile(example_pvol, pvolfile_out)
-#' }
+#'
+#' # clean up
+#' file.remove(pvolfile_out)
 write_pvolfile <- function(pvol, file, overwrite = FALSE, infer_dtype = FALSE) {
   assertthat::assert_that(is.pvol(pvol))
   if (!overwrite) {

--- a/man/calculate_vp.Rd
+++ b/man/calculate_vp.Rd
@@ -214,7 +214,6 @@ be downloaded at \url{https://s3.amazonaws.com/mistnet/mistnet_nexrad.pt}.
 }
 }
 \examples{
-\dontrun{
 # Locate and read the polar volume example file
 pvolfile <- system.file("extdata", "volume.h5", package = "bioRad")
 
@@ -229,7 +228,6 @@ vp
 
 # Clean up
 file.remove("~/volume.h5")
-}
 }
 \references{
 Dokter et al. (2011) is the main reference for the profiling algorithm

--- a/man/composite_ppi.Rd
+++ b/man/composite_ppi.Rd
@@ -108,7 +108,6 @@ mean (lat, lon) location.
 This function is a prototype and under active development
 }
 \examples{
-\dontrun{
 # Locate and read the polar volume example file
 pvolfile <- system.file("extdata", "volume.h5", package = "bioRad")
 pvol <- read_pvolfile(pvolfile)
@@ -119,7 +118,7 @@ ppis <- lapply(pvol$scans, project_as_ppi)
 # Overlay the ppis, calculating the maximum value observed
 # across the available scans at each geographic location
 composite <- composite_ppi(ppis, method = "max")
-
+\dontrun{
 # Download basemap
 bm <- download_basemap(composite)
 

--- a/man/download_pvolfiles.Rd
+++ b/man/download_pvolfiles.Rd
@@ -36,13 +36,17 @@ Download a selection of polar volume (\code{pvol}) files from the
 }
 \examples{
 \dontrun{
-dir.create("~/bioRad_tmp_files")
+create temporary directory
+temp_dir <- paste0(tempdir(),"/bioRad_tmp_files")
+dir.create(temp_dir)
 download_pvolfiles(
   date_min = as.POSIXct("2016-10-02 20:00", tz = "UTC"),
   date_max = as.POSIXct("2016-10-02 20:05", tz = "UTC"),
   radar = "KBBX",
-  directory = "~/bioRad_tmp_files",
+  directory = temp_dir,
   overwrite = TRUE
 )
+# Clean up
+unlink(temp_dir, recursive = T)
 }
 }

--- a/man/download_vpfiles.Rd
+++ b/man/download_vpfiles.Rd
@@ -38,16 +38,17 @@ these are stored as monthly zips per radar.
 # Will successfully download 2016-10 files, but show 404 error for
 # 2016-11 files, since these are not available.
 \dontrun{
-dir.create("~/bioRad_tmp_files")
+temp_dir <- paste0(tempdir(),"/bioRad_tmp_files")
+dir.create(temp_dir)
 download_vpfiles(
   date_min = "2016-10-01",
   date_max = "2016-11-30",
   radars = c("bejab", "bewid"),
-  directory = "~/bioRad_tmp_files",
+  directory = temp_dir,
   overwrite = TRUE
 )
 # Clean up
-unlink("~/bioRad_tmp_files", recursive = T)
+unlink(temp_dir, recursive = T)
 }
 }
 \seealso{

--- a/man/example_scan.Rd
+++ b/man/example_scan.Rd
@@ -20,13 +20,11 @@ data(example_scan)
 # Get summary info
 example_scan
 
-# example_scan was created with
-\dontrun{
-pvolfile <- system.file("extdata", "volume.h5", package = "bioRad")
-pvol <- read_pvolfile(pvolfile)
-example_scan <- pvol$scans[[1]]
-save(example_scan, file = "data/example_scan.rda")
-}
+## example_scan was created with:
+# pvolfile <- system.file("extdata", "volume.h5", package = "bioRad")
+# pvol <- read_pvolfile(pvolfile)
+# example_scan <- pvol$scans[[1]]
+# save(example_scan, file = "data/example_scan.rda")
 }
 \seealso{
 \itemize{

--- a/man/example_vp.Rd
+++ b/man/example_vp.Rd
@@ -20,12 +20,10 @@ data(example_vp)
 # Get summary info
 example_vp
 
-# example_vp was created with
-\dontrun{
-vpfile <- system.file("extdata", "profile.h5", package = "bioRad")
-example_vp <- read_vpfiles(vpfile)
-save(example_vp, file = "data/example_vp.rda")
-}
+## example_vp was created with:
+# vpfile <- system.file("extdata", "profile.h5", package = "bioRad")
+# example_vp <- read_vpfiles(vpfile)
+# save(example_vp, file = "data/example_vp.rda")
 }
 \seealso{
 \itemize{

--- a/man/example_vpts.Rd
+++ b/man/example_vpts.Rd
@@ -20,18 +20,16 @@ data(example_vpts)
 # Get summary info
 example_vpts
 
-# example_vpts was created with
-\dontrun{
-vptsfile <- system.file("extdata", "vpts.txt.zip", package = "bioRad")
-utils::unzip(vptsfile, exdir = (dirname(vptsfile)), junkpaths = TRUE)
-vptsfile <- substr(vptsfile, 1, nchar(vptsfile) - 4)
-example_vpts <- read_vpts(vptsfile, radar = "KBGM", wavelength = "S")
-rcs(example_vpts) <- 11
-sd_vvp_threshold(example_vpts) <- 2
-example_vpts$attributes$where$lat <- 42.2
-example_vpts$attributes$where$lon <- -75.98
-save(example_vpts, file = "data/example_vpts.rda", compress = "xz")
-}
+## example_vpts was created with
+# vptsfile <- system.file("extdata", "vpts.txt.zip", package = "bioRad")
+# utils::unzip(vptsfile, exdir = (dirname(vptsfile)), junkpaths = TRUE)
+# vptsfile <- substr(vptsfile, 1, nchar(vptsfile) - 4)
+# example_vpts <- read_vpts(vptsfile, radar = "KBGM", wavelength = "S")
+# rcs(example_vpts) <- 11
+# sd_vvp_threshold(example_vpts) <- 2
+# example_vpts$attributes$where$lat <- 42.2
+# example_vpts$attributes$where$lon <- -75.98
+# save(example_vpts, file = "data/example_vpts.rda", compress = "xz")
 }
 \seealso{
 \itemize{

--- a/man/integrate_to_ppi.Rd
+++ b/man/integrate_to_ppi.Rd
@@ -170,7 +170,6 @@ ppi <- integrate_to_ppi(pvol, example_vp, nx = 50, ny = 50)
 # 0-2000 cm^2/km^2 color scale
 plot(ppi, zlim = c(0, 2000))
 
-\dontrun{
 # Calculate the range-corrected ppi on finer 2000m x 2000m pixel raster
 ppi <- integrate_to_ppi(pvol, example_vp, res = 2000)
 
@@ -178,9 +177,11 @@ ppi <- integrate_to_ppi(pvol, example_vp, res = 2000)
 # 0-200 birds/km^2 color scale
 plot(ppi, param = "VID", zlim = c(0, 200))
 
+\dontrun{
 # Download a basemap and map the ppi
 bm <- download_basemap(ppi)
 map(ppi, bm)
+}
 
 # The ppi can also be projected on a user-defined raster, as follows:
 
@@ -203,7 +204,6 @@ ppi <- integrate_to_ppi(
   xlim = c(-50000, 50000), ylim = c(-50000, 50000)
 )
 plot(ppi, param = "VID", zlim = c(0, 200))
-}
 }
 \references{
 \itemize{

--- a/man/plot.scan.Rd
+++ b/man/plot.scan.Rd
@@ -57,12 +57,11 @@ model (ODIM), see Table 16 in the
 \examples{
 # Plot reflectivity
 plot(example_scan, param = "DBZH")
-\dontrun{
+
 # Change the range of reflectivities to plot, from -10 to 10 dBZ
 plot(example_scan, param = "DBZH", zlim = c(-10, 10))
 
 # Change the scale name, change the color palette to Viridis colors
 plot(example_scan, param = "DBZH", zlim = c(-10, 10)) +
   viridis::scale_fill_viridis(name = "dBZ")
-}
 }

--- a/man/read_vpfiles.Rd
+++ b/man/read_vpfiles.Rd
@@ -28,9 +28,6 @@ vpfile
 # load the file:
 read_vpfiles(vpfile)
 
-# load multiple files at once:
-\dontrun{
+# to load multiple files at once:
 # read_vpfiles(c("my/path/profile1.h5", "my/path/profile2.h5", ...))
-}
-
 }

--- a/man/scan_to_raster.Rd
+++ b/man/scan_to_raster.Rd
@@ -66,6 +66,7 @@ uses \link{scan_to_spatial} to georeference the scan's pixels. If multiple scan 
 the same raster pixel, the last added pixel is given (see \link[raster:rasterize]{rasterize} for details).
 }
 \examples{
+\dontrun{
 # default projects full extent on 100x100 pixel raster:
 scan_to_raster(example_scan)
 
@@ -75,4 +76,5 @@ scan_to_raster(example_scan, ylim = c(55, 57), xlim = c(12, 13), res = .1)
 # using a template raster
 template_raster <- raster::raster(raster::extent(12, 13, 56, 58), crs = sp::CRS("+proj=longlat"))
 scan_to_raster(example_scan, raster = template_raster)
+}
 }

--- a/man/vplist_to_vpts.Rd
+++ b/man/vplist_to_vpts.Rd
@@ -24,9 +24,9 @@ Used as helper function for the method dispatched \code{bind_into_vpts} and
 keeping backward compatibility with the \code{vpts} function.
 }
 \examples{
-\dontrun{
-vps <- read_vpfiles(c("my/path/profile1.h5", "my/path/profile2.h5", ...))
+vpfile1 <- system.file("extdata", "profile.h5", package = "bioRad")
+vpfile2 <- vpfile1
+vps <- read_vpfiles(c(vpfile1,vpfile2))
 ts <- bind_into_vpts(vps)
-}
 }
 \keyword{internal}

--- a/man/write_pvolfile.Rd
+++ b/man/write_pvolfile.Rd
@@ -32,7 +32,8 @@ example_pvol <- read_pvolfile(pvolfile)
 
 # write the file:
 pvolfile_out <- paste0(tempdir(),"pvolfile_out.h5")
-\dontrun{
 write_pvolfile(example_pvol, pvolfile_out)
-}
+
+# clean up
+file.remove(pvolfile_out)
 }


### PR DESCRIPTION
Addressing issue #528 

Removed dontrun blocks as much as possible. Remaining example blocks in \dontrun blocks are there because:
* execution time > 5s, which could trigger a note on CRAN
* the example downloads remote data, and therefore requires an internet connection

Also made sure a `devtools::check(run_dont_run=TRUE)` completes successfully without triggering warnings/errors, fixing #562