### PR TITLE
Re-enable tests for read_stdout()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bioRad
 Title: Biological Analysis and Visualization of Weather Radar Data
-Version: 0.7.0.9590
+Version: 0.7.0.9601
 Description: Extract, visualize and summarize aerial movements of birds and
     insects from weather radar data. See <doi:10.1111/ecog.04028>
     for a software paper describing package and methodologies.

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -1,8 +1,5 @@
 .onLoad <- function(libname, pkgname) {
   register_all_s3_methods() # dynamically registers non-imported pkgs (tidyverse) # nocov
-  if (inherits(try(find.package("vol2birdR"), silent = TRUE),"try-error")) {
-    warning("Package 'vol2birdR' is not found. Please see https://adokter.github.io/vol2birdR/ for installation instructions.")
-  }
 }
 .onAttach <- function(libname, pkgname) {
   packageStartupMessage(paste("Welcome to", pkgname, "version", utils::packageVersion(pkgname)))

--- a/R/read_stdout.R
+++ b/R/read_stdout.R
@@ -31,7 +31,7 @@ read_stdout <- function(file, radar, lat, lon, height, wavelength = "C", sep = "
     stop(paste("File", file, "is empty."))
   }
 
-  # currently only two delimitors supported
+  # currently only two delimiters supported
   # "" for legacy vol2bird output, "," for csv output
   sep_msg <- "'sep' should be either \",\" or \"\""
   assertthat::assert_that(assertthat::is.string(sep),

--- a/R/read_stdout.R
+++ b/R/read_stdout.R
@@ -30,6 +30,15 @@ read_stdout <- function(file, radar, lat, lon, height, wavelength = "C", sep = "
   if (file.size(file) == 0) {
     stop(paste("File", file, "is empty."))
   }
+
+  # currently only two delimitors supported
+  # "" for legacy vol2bird output, "," for csv output
+  sep_msg <- "'sep' should be either \",\" or \"\""
+  assertthat::assert_that(assertthat::is.string(sep),
+                          msg = sep_msg)
+  assertthat::assert_that(sep == "" || sep == ",",
+                          msg = sep_msg)
+
   if (missing(radar) && sep == "") {
     stop("'radar' argument missing. Required to specify a radar identifier.")
   }
@@ -73,14 +82,6 @@ read_stdout <- function(file, radar, lat, lon, height, wavelength = "C", sep = "
   if (wavelength == "S") {
     wavelength <- 10.6
   }
-
-  # currently only two delimitors supported
-  # "" for legacy vol2bird output, "," for csv output
-  sep_msg <- "'sep' should be either \",\" or \"\""
-  assertthat::assert_that(assertthat::is.string(sep),
-                          msg = sep_msg)
-  assertthat::assert_that(sep == "" || sep == ",",
-                          msg = sep_msg)
 
   # header of the data file
   header.names.short <- c(

--- a/R/read_stdout.R
+++ b/R/read_stdout.R
@@ -30,23 +30,25 @@ read_stdout <- function(file, radar, lat, lon, height, wavelength = "C", sep = "
   if (file.size(file) == 0) {
     stop(paste("File", file, "is empty."))
   }
-  if (!missing(lat)) {
-    if (!is.numeric(lat) || lat < -90 || lat > 90) {
-      stop("'lat' should be numeric between -90 and 90 degrees")
-    }
-  }
-  if (!missing(lon)) {
-    if (!is.numeric(lon) || lat < -360 || lat > 360) {
-      stop("'lon' should be numeric between -360 and 360 degrees")
-    }
-  }
-  if (!missing(height)) {
-    if (!is.numeric(height) || height < 0) {
-      stop("'height' should be a positive number of meters above sea level")
-    }
-  }
   if (missing(radar) && sep == "") {
     stop("'radar' argument missing. Required to specify a radar identifier.")
+  }
+  if (!missing(lat)) {
+    lat_msg <- "'lat' should be a single numeric between -90 and 90 degrees"
+    assertthat::assert_that(assertthat::is.number(lat), msg = lat_msg)
+    assertthat::assert_that(lat > -90, msg = lat_msg)
+    assertthat::assert_that(lat < 90, msg = lat_msg)
+  }
+  if (!missing(lon)) {
+    lon_msg <- "'lon' should be a single numeric between -360 and 360 degrees"
+    assertthat::assert_that(assertthat::is.number(lon), msg = lon_msg)
+    assertthat::assert_that(lon > -360, msg = lon_msg)
+    assertthat::assert_that(lon < 360, msg = lon_msg)
+  }
+  if (!missing(height)) {
+    height_msg <- "'height' should be a single positive number of meters above sea level"
+    assertthat::assert_that(assertthat::is.number(height), msg = height_msg)
+    assertthat::assert_that(height > 0, msg = height_msg)
   }
   if (missing(wavelength)) {
     warning(paste("No 'wavelength' argument provided, assuming radar operates",

--- a/R/read_stdout.R
+++ b/R/read_stdout.R
@@ -50,25 +50,37 @@ read_stdout <- function(file, radar, lat, lon, height, wavelength = "C", sep = "
     assertthat::assert_that(assertthat::is.number(height), msg = height_msg)
     assertthat::assert_that(height > 0, msg = height_msg)
   }
+
   if (missing(wavelength)) {
     warning(paste("No 'wavelength' argument provided, assuming radar operates",
-      " at ", wavelength, "-band",
-      sep = ""
+                  " at ", wavelength, "-band",
+                  sep = ""
     ))
   }
+  wavelength_msg <-
+    glue::glue(
+      "'wavelength' should be a single positive number",
+      ", or one of 'C' or 'S' for C-band and S-band radar, respectively."
+    )
+  assertthat::assert_that(
+    (assertthat::is.number(wavelength) && wavelength > 0) ||
+      (assertthat::is.scalar(wavelength) && wavelength %in% c("C","S")),
+    msg = wavelength_msg)
+
   if (wavelength == "C") {
     wavelength <- 5.3
   }
   if (wavelength == "S") {
     wavelength <- 10.6
   }
-  if (!is.numeric(wavelength) || length(wavelength) > 1) {
-    stop("Not a valid 'wavelength' argument.")
-  }
 
   # currently only two delimitors supported
   # "" for legacy vol2bird output, "," for csv output
-  assertthat::assert_that(sep == "" || sep == ",")
+  sep_msg <- "'sep' should be either \",\" or \"\""
+  assertthat::assert_that(assertthat::is.string(sep),
+                          msg = sep_msg)
+  assertthat::assert_that(sep == "" || sep == ",",
+                          msg = sep_msg)
 
   # header of the data file
   header.names.short <- c(

--- a/tests/testthat/test-read_stdout.R
+++ b/tests/testthat/test-read_stdout.R
@@ -1,0 +1,125 @@
+vptsfile <- system.file("extdata", "example_vpts.txt", package = "bioRad")
+
+test_that("read_stdout() returns error on incorrect parameters", {
+  empty_file <- tempfile()
+  file.create(empty_file)
+
+  expect_error(
+    read_stdout(empty_file),
+    regex = glue::glue("File {empty_file} is empty."),
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(tempfile()),
+    regex = glue::glue("doesn't exist.")
+  )
+  expect_error(
+    read_stdout(vptsfile, lat = -180),
+    regexp = "'lat' should be numeric between -90 and 90 degrees",
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, lat = 180),
+    regexp = "'lat' should be numeric between -90 and 90 degrees",
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, lat = "a"),
+    regexp = "'lat' should be numeric between -90 and 90 degrees",
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, lat = c(48, 32)),
+    regexp = "'lat' should be a single numeric between -90 and 90 degrees",
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, lat = 66),
+    regexp = "'radar' argument missing. Required to specify a radar identifier.",
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, lon = -180),
+    regexp = "'radar' argument missing. Required to specify a radar identifier.",
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, lon = -1080, lat = 38),
+    regexp = "lon' should be numeric between -360 and 360 degrees",
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, height = -1),
+    regexp = "'height' should be a positive number of meters above sea level",
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, height = NA),
+    regexp = "height is not a number (a length one numeric vector).",
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, height = NA),
+    regexp = "height is not a number (a length one numeric vector).",
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, radar = "KBGM", height = seq(50)),
+    regexp = "height is not a number (a length one numeric vector).",
+    fixed = TRUE
+  )
+
+  wavelength_msg <-
+    glue::glue(
+      "'wavelength' should be a single positive number",
+      ", or one of 'C' or 'S' for C-band and S-band radar, respectively."
+    )
+  expect_error(
+    read_stdout(vptsfile, wavelength = "a", radar = "KBGM"),
+    regexp = wavelength_msg,
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, wavelength = -12, radar = "KBGM"),
+    regexp = wavelength_msg,
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, wavelength = 1:3, radar = "KBGM"),
+    regexp = wavelength_msg,
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, wavelength = "Q", radar = "KBGM"),
+    regexp = wavelength_msg,
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, wavelength = "S", radar = "KBGM", sep = "|"),
+    regexp = "'sep' should be either \",\" or \"\"",
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, sep = NA),
+    regexp = "'sep' should be either \",\" or \"\"",
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, sep = c(",", "&")),
+    regexp = "'sep' should be either \",\" or \"\"",
+    fixed = TRUE
+  )
+  expect_error(
+    read_stdout(vptsfile, sep = c(",", "||")),
+    regexp = "'sep' should be either \",\" or \"\"",
+    fixed = TRUE
+  )
+})
+
+test_that("read_stdout() warns for missing wavelength", {
+  expect_warning(
+    read_stdout(vptsfile, radar = "KBGM"),
+    regexp = "No 'wavelength' argument provided, assuming radar operates at C-band",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-read_stdout.R
+++ b/tests/testthat/test-read_stdout.R
@@ -105,7 +105,7 @@ test_that("read_stdout() returns error on incorrect parameters", {
     fixed = TRUE
   )
   expect_error(
-    read_stdout(vptsfile, sep = c(",", "&")),
+    read_stdout(vptsfile, sep = c(",", "&"), wavelength = "C"),
     regexp = "'sep' should be either \",\" or \"\"",
     fixed = TRUE
   )

--- a/tests/testthat/test-read_stdout.R
+++ b/tests/testthat/test-read_stdout.R
@@ -100,7 +100,7 @@ test_that("read_stdout() returns error on incorrect parameters", {
     fixed = TRUE
   )
   expect_error(
-    read_stdout(vptsfile, sep = NA),
+    suppressWarnings(read_stdout(vptsfile, radar = "KBGM", sep = NA)),
     regexp = "'sep' should be either \",\" or \"\"",
     fixed = TRUE
   )

--- a/tests/testthat/test-read_stdout.R
+++ b/tests/testthat/test-read_stdout.R
@@ -14,22 +14,22 @@ test_that("read_stdout() returns error on incorrect parameters", {
     regex = glue::glue("doesn't exist.")
   )
   expect_error(
-    read_stdout(vptsfile, lat = -180),
-    regexp = "'lat' should be numeric between -90 and 90 degrees",
+    read_stdout(vptsfile, radar = "KBGM", lat = -180),
+    regexp = "'lat' should be a single numeric between -90 and 90 degrees",
     fixed = TRUE
   )
   expect_error(
-    read_stdout(vptsfile, lat = 180),
-    regexp = "'lat' should be numeric between -90 and 90 degrees",
+    read_stdout(vptsfile, radar = "KBGM", lat = 180),
+    regexp = "'lat' should be a single numeric between -90 and 90 degrees",
     fixed = TRUE
   )
   expect_error(
-    read_stdout(vptsfile, lat = "a"),
-    regexp = "'lat' should be numeric between -90 and 90 degrees",
+    read_stdout(vptsfile, radar = "KBGM", lat = "a"),
+    regexp = "'lat' should be a single numeric between -90 and 90 degrees",
     fixed = TRUE
   )
   expect_error(
-    read_stdout(vptsfile, lat = c(48, 32)),
+    read_stdout(vptsfile, radar = "KBGM", lat = c(48, 32)),
     regexp = "'lat' should be a single numeric between -90 and 90 degrees",
     fixed = TRUE
   )
@@ -44,28 +44,28 @@ test_that("read_stdout() returns error on incorrect parameters", {
     fixed = TRUE
   )
   expect_error(
-    read_stdout(vptsfile, lon = -1080, lat = 38),
-    regexp = "lon' should be numeric between -360 and 360 degrees",
+    read_stdout(vptsfile, radar = "KBGM", lon = -1080, lat = 38),
+    regexp = "'lon' should be a single numeric between -360 and 360 degrees",
     fixed = TRUE
   )
   expect_error(
-    read_stdout(vptsfile, height = -1),
-    regexp = "'height' should be a positive number of meters above sea level",
+    read_stdout(vptsfile, radar = "KBGM", height = -1),
+    regexp = "'height' should be a single positive number of meters above sea level",
     fixed = TRUE
   )
   expect_error(
-    read_stdout(vptsfile, height = NA),
-    regexp = "height is not a number (a length one numeric vector).",
+    read_stdout(vptsfile, radar = "KBGM", height = NA),
+    regexp = "'height' should be a single positive number of meters above sea level",
     fixed = TRUE
   )
   expect_error(
-    read_stdout(vptsfile, height = NA),
-    regexp = "height is not a number (a length one numeric vector).",
+    read_stdout(vptsfile, radar = "KBGM", height = NA),
+    regexp = "'height' should be a single positive number of meters above sea level",
     fixed = TRUE
   )
   expect_error(
     read_stdout(vptsfile, radar = "KBGM", height = seq(50)),
-    regexp = "height is not a number (a length one numeric vector).",
+    regexp = "'height' should be a single positive number of meters above sea level",
     fixed = TRUE
   )
 


### PR DESCRIPTION
Tests for `read_vpts()` were added by @PietrH. As part of #590 that function is renamed to `read_stdout()`, causing a merge conflict with between the tests for the new `read_vpts()` and those intended for `read_stdout()`. This resulted in the latter test being removed in https://github.com/adokter/bioRad/commit/3358d976e39fefb6e1d8eac80fdf1b93faf9665e.

This PR re-enables those tests, now calling `read_stdout()`. I notice however that some of the tests fail. I think this is due to the fact the tests expecting a specific error are order sensitive. E.g. a test for `read_stdout(vptsfile, lat = "a")` expects an error related to the latitude not being an integer, but can also fail because the radar is missing. I would update those test to provide all the necessary parameters _except_ the one we need to test, so `read_stdout(vptsfile, radar = "KGBM", lat = "a")`.

@PietrH since you worked on these test, would you be willing to correct them?