### PR TITLE
handle delta linear interpolation if it is a numeric of len 0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bioRad
 Title: Biological Analysis and Visualization of Weather Radar Data
-Version: 0.7.1.9000
+Version: 0.7.1.9001
 Description: Extract, visualize and summarize aerial movements of birds and
     insects from weather radar data. See Dokter, A. M. et al. (2018) 
     "bioRad: biological analysis and visualization of weather radar data" <doi:10.1111/ecog.04028>

--- a/R/integrate_profile.R
+++ b/R/integrate_profile.R
@@ -262,7 +262,9 @@ integrate_profile.vp <- function(x, alt_min = 0, alt_max = Inf, alpha = NA,
     height_quantile_upper <- denscum[min(height_index_lower+1,length(denscum))]
     # 4) do a linear interpolation to estimate the altitude at the quantile of interest
     delta_linear_interpolation <- (height_quantile-height_quantile_lower)*(height_upper-height_lower)/(height_quantile_upper-height_quantile_lower)
-    if(is.na(delta_linear_interpolation)) delta_linear_interpolation=0
+    if(length(delta_linear_interpolation) == 0 || is.na(delta_linear_interpolation)) {
+    delta_linear_interpolation = 0
+    }
     # 5) store the quantile flight altitude as height
     height <- height_lower+delta_linear_interpolation
   }


### PR DESCRIPTION
Resolves error that arises when `delta_linear_interpolation` is numeric(0)

```
Error in if (is.na(delta_linear_interpolation)) delta_linear_interpolation = 0 : 
  argument is of length zero
```