### PR TITLE
fix use of height_quantile argument in integrate_profile() (#627)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * skip tests for `calculate_vp()` when vol2birdR package is not installed (#624)
 
+* fix a bug in the calculation of flight altitude quantiles (#627), which caused underestimation of flight altitude quantiles by up to one altitude bin.
+
 # bioRad 0.7.1
 
 Rebuilds documentation with examples formatted as per CRAN requirements.


### PR DESCRIPTION
This PR fixes issue #627. Note that this fix causes flight altitude quantiles as calculated when setting argument `height_quantile` in `integrate_profile()` will be different up to one height bin.