### PR TITLE
fix single_pol flag in calculate_vp()

### DIFF
--- a/R/calculate_vp.R
+++ b/R/calculate_vp.R
@@ -357,6 +357,7 @@ calculate_vp <- function(file, vpfile = "", pvolfile_out = "",
     config$minNyquist <- nyquist_min
     config$dbzType <- dbz_quantity
     config$dualPol <- dual_pol
+    config$singlePol <- single_pol
     config$dealiasVrad <- dealias
     if (!missing(sd_vvp_threshold)) config$stdDevMinBird <- sd_vvp_threshold
   } else {


### PR DESCRIPTION
fix that enables setting `single_pol=FALSE` in `calculate_vp()`. Due to a bug (#645) this flag was always TRUE