### PR TITLE
fix label of plot.vpi() for quantity vir, disable read_vpts test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# bioRad 0.8.1.9000
+
+* correct units specified in plot label for quantity VIR (#674)
 
 # bioRad 0.8.1
 

--- a/R/plot.vpi.R
+++ b/R/plot.vpi.R
@@ -89,7 +89,7 @@ plot.vpi <- function(x, quantity = "mtr", xlab = "time",
     if (quantity == "mtr") ylab <- "migration traffic rate [#/km/h]"
     if (quantity == "rtr") ylab <- expression("reflectivity traffic rate [cm"^2 * "/km/h]")
     if (quantity == "vid") ylab <- expression("vertically integrated density [#/km"^2 * "]")
-    if (quantity == "vir") ylab <- expression("vertically integrated reflectivity [cm"^2 * "/km/h]")
+    if (quantity == "vir") ylab <- expression("vertically integrated reflectivity [cm"^2 * "/km"^2 * "]")
     if (quantity == "mt") ylab <- expression("(cumulative) migration traffic [#/km]")
     if (quantity == "rt") ylab <- expression("(cumulative) reflectivity traffic [cm"^2 * "/km]")
     if (quantity == "ff") ylab <- expression("vertically averaged ground speed [m/s]")

--- a/tests/testthat/test-read_vpts.R
+++ b/tests/testthat/test-read_vpts.R
@@ -124,6 +124,7 @@ test_that("read_vpts() returns error on multiple radars in vp hdf5 files", {
 })
 
 test_that("read_vpts() can read remote (gzipped) VPTS CSV files", {
+  testthat::skip("Ignoring test until readr can read remote gzipped files (FIXME)")
   skip_if_offline()
 
   gz_urls <- urls[grepl("\\.gz$", urls)]


### PR DESCRIPTION
* fixes a mislabeled plot axis for vertically integrated reflectivity (VIR). y-axis label incorrectly mentioned cm^2/km/h, while it should be cm^2/km^2
* disables a test in test-read_vpts.R related to an issue in `read_csv()` of package readr