### PR TITLE
add zoomin argument to increase map resolution

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,10 +52,15 @@ jobs:
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
         run: |
-          pak::local_system_requirements(execute = TRUE)
-          pak::pkg_system_requirements("rcmdcheck", execute = TRUE)
-          pak::pkg_system_requirements("proj4", execute = TRUE) # Using same proj for now...
-          pak::pkg_system_requirements("hdf5r", execute = TRUE) # Using same hdf5 for now...
+          pak::pkg_sysreqs("local::.", dependencies = TRUE)$install_script
+          pak::pkg_sysreqs("rcmdcheck")$install_scripts
+          pak::pkg_sysreqs("proj4")$install_scripts
+          pak::pkg_sysreqs("hdf5r")$install_scripts
+          #pak::local_system_requirements(execute = TRUE)
+          #pak::pkg_system_requirements("rcmdcheck", execute = TRUE)
+          #pak::pkg_system_requirements("proj4", execute = TRUE) # Using same proj for now...
+          #pak::pkg_system_requirements("hdf5r", execute = TRUE) # Using same hdf5 for now...
+
         shell: Rscript {0}
       - name: Install dependencies
         run: |

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * discard profiles with misspecified altitude bins in `as.vpts()` and `read_vpts()` (#684)
 
+* new argument `zoomin` for function `bioRad::map()` to increase basemap resolution (#689)
+
 # bioRad 0.8.1
 
 ## bugfixes

--- a/R/map.R
+++ b/R/map.R
@@ -3,7 +3,7 @@
 #' Plots a plan position indicator (`ppi`) on a base layer
 #'
 #' @param x A `ppi` object.
-#' @param map Basemap to use, one of `rosm::osm.types()`
+#' @param map Basemap to use, one of [rosm::osm.types()]
 #' @param param Character. Scan parameter to plot, e.g. `DBZH` or `VRADH`. See
 #'   [summary.param()] for commonly available parameters.
 #' @param alpha Numeric. Transparency of the data, value between 0 and 1.
@@ -20,6 +20,7 @@
 #' @param n_color Numeric. Number of colors (>=1) to use in the palette.
 #' @param palette Character vector. Hexadecimal color values defining the plot
 #'   color scale, e.g. output from [viridisLite::viridis()].
+#' @param zoomin Numeric. Maps to [ggspatial::annotation_map_tile()]
 #' @param ... Arguments passed to [ggplot2::ggplot()].
 #' @importFrom methods as
 #' @return A ggplot object
@@ -81,7 +82,7 @@ map <- function(x, ...) {
 #' @export
 map.ppi <- function(x, map="cartolight", param, alpha = 0.7, xlim, ylim, zlim = c(-20, 20),
                     ratio, radar_size = 3, radar_color = "#202020", n_color = 1000,
-                    palette = NA, ...) {
+                    palette = NA, zoomin = -2, ...) {
 
   stopifnot(inherits(x, "ppi"))
 
@@ -221,7 +222,7 @@ map.ppi <- function(x, map="cartolight", param, alpha = 0.7, xlim, ylim, zlim = 
 
   mymap <- suppressWarnings(
     ggplot2::ggplot() +
-      ggspatial::annotation_map_tile(type = map) +
+      ggspatial::annotation_map_tile(type = map, zoomin = zoomin) +
       ggplot2::geom_raster(data = rdf, ggplot2::aes(x = x, y = y, fill = fill), na.rm = TRUE, interpolate = FALSE) +
       ggplot2::scale_fill_identity(na.value = "transparent") +
       ggplot2::geom_point(data = radar_df, ggplot2::aes(x = X, y = Y),

--- a/man/map.Rd
+++ b/man/map.Rd
@@ -20,6 +20,7 @@ map(x, ...)
   radar_color = "#202020",
   n_color = 1000,
   palette = NA,
+  zoomin = -2,
   ...
 )
 }
@@ -28,7 +29,7 @@ map(x, ...)
 
 \item{...}{Arguments passed to \code{\link[ggplot2:ggplot]{ggplot2::ggplot()}}.}
 
-\item{map}{Basemap to use, one of \code{rosm::osm.types()}}
+\item{map}{Basemap to use, one of \code{\link[rosm:deprecated]{rosm::osm.types()}}}
 
 \item{param}{Character. Scan parameter to plot, e.g. \code{DBZH} or \code{VRADH}. See
 \code{\link[=summary.param]{summary.param()}} for commonly available parameters.}
@@ -55,6 +56,8 @@ position.}
 
 \item{palette}{Character vector. Hexadecimal color values defining the plot
 color scale, e.g. output from \code{\link[viridisLite:viridis]{viridisLite::viridis()}}.}
+
+\item{zoomin}{Numeric. Maps to \code{\link[ggspatial:annotation_map_tile]{ggspatial::annotation_map_tile()}}}
 }
 \value{
 A ggplot object


### PR DESCRIPTION
fixes issue #689, exposes argument `zoomin` of `ggspatial::annotation_map_tile()` to `bioRad::map()`