### PR TITLE
fix issue #635 (continued)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * new argument `zoomin` for function `bioRad::map()` to increase basemap resolution (#689)
 
+* correct type of gap field in vpts objects for profiles stored in ODIM HDF5 format (.h5) (#635, #691)
+
 # bioRad 0.8.1
 
 ## bugfixes

--- a/R/read_vpfiles.R
+++ b/R/read_vpfiles.R
@@ -35,6 +35,11 @@ read_vp <- function(file) {
   quantities <- gsub("HGHT", "height", quantities)
   names(profile) <- quantities
 
+  # make sure gap is logical
+  if("gap" %in% quantities){
+     profile$gap = as.logical(profile$gap)
+  }
+
   # extract attributes
   attribs.how <- rhdf5::h5readAttributes(file, "how")
   attribs.what <- rhdf5::h5readAttributes(file, "what")


### PR DESCRIPTION
fixes incorrect type for gap argument when reading a vpfile in hdf5 (.h5) format