### PR TITLE
Plotting tweaks: bug fix for x label, and support night shading with missing data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Fixes a bug that prevented a data.frame to be converted to a vpts object with as.vpts() when profiles are not sorted in datetime and height (#692).
 
+* Bugfix for ignored `xlab` argument in `plot.vpi()` and night shading fix for dealing with NA values (#693)
+
 # bioRad 0.8.1
 
 ## bugfixes

--- a/R/plot.vpi.R
+++ b/R/plot.vpi.R
@@ -116,7 +116,7 @@ plot.vpi <- function(x, quantity = "mtr", xlab = "time",
 
   # plot the data
   plot(x$datetime, x[quantity][[1]],
-    type = "l", xlab = "time", ylab = ylab,
+    type = "l", xlab = xlab, ylab = ylab,
     ylim = ylim, main = main, xaxs = "i", yaxs = "i", ...
   )
 
@@ -145,8 +145,8 @@ plot.vpi <- function(x, quantity = "mtr", xlab = "time",
     # determine the plot range of the night time shading
     if (missing(ylim)) {
       pol.range <- c(
-        min(c(0, 2 * min(x[quantity][[1]]))),
-        2 * max(x[quantity][[1]])
+        min(c(0, 2 * min(x[quantity][[1]], na.rm = TRUE))),
+        2 * max(x[quantity][[1]], na.rm = TRUE)
       )
     } else {
       pol.range <- ylim
@@ -167,7 +167,7 @@ plot.vpi <- function(x, quantity = "mtr", xlab = "time",
     # plot the data again on top of the shading
     graphics::points(x$datetime, x[quantity][[1]],
       type = "l",
-      xlab = "time", ylab = ylab, ylim = ylim, main = main, ...
+      xlab = xlab, ylab = ylab, ylim = ylim, main = main, ...
     )
   }
 }


### PR DESCRIPTION
Change 1: fix a bug where the `xlab` argument passed to `plot.vpi` is not used and the x label is hard coded to "time" when `plot` is called.

Change 2: ignore NAs when automatically determining the y axis limits for night shading. This allows the night shading to work properly if the plotted quantity has NAs, which can be useful if you want to filter some values from plotting.