### PR TITLE
fix default s-band value sd_vvp_threshold()

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 * Bugfix for ignored `xlab` argument in `plot.vpi()` and night shading fix for dealing with NA values (#693)
 
+* Bugfix for incorrect default sd_vvp_threshold value for S-band data (2 m/s instead of correct 1 m/s) (#695)
+
 # bioRad 0.8.1
 
 ## bugfixes

--- a/R/calculate_vp.R
+++ b/R/calculate_vp.R
@@ -364,14 +364,16 @@ calculate_vp <- function(file, vpfile = "", pvolfile_out = "",
     config$dualPol <- dual_pol
     config$singlePol <- single_pol
     config$dealiasVrad <- dealias
-    if (!missing(sd_vvp_threshold)) config$stdDevMinBird <- sd_vvp_threshold
-  } else {
-    # setting stdDevMinBird triggers it to be set according to wavelength (1 m/s for S-band, 2 m/s for C-band)
-    config$stdDevMinBird <- -1
+    if (!missing(sd_vvp_threshold)){
+       config$stdDevMinBird <- sd_vvp_threshold
+    } else {
+       # setting stdDevMinBird triggers it to be set according to wavelength (1 m/s for S-band, 2 m/s for C-band)
+       config$stdDevMinBird <- -1
+    }
+    config$mistNetElevs <- mistnet_elevations
+    config$useMistNet <- mistnet
+    if (!missing(local_mistnet) & mistnet) config$mistNetPath <- local_mistnet
   }
-  config$mistNetElevs <- mistnet_elevations
-  config$useMistNet <- mistnet
-  if (!missing(local_mistnet) & mistnet) config$mistNetPath <- local_mistnet
 
   # run vol2bird
   ## use helper to allow vol2bird to silence output (vol2bird doesn't actually

--- a/bioRad.Rproj
+++ b/bioRad.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: b32cc17d-04d6-4782-95b0-7bdaa77d889b
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
Bugfix that caused default sd_vvp_threshold value to be 2 m/s instead of 1 m/s as mentioned in the documentation. Fixes issue #99