### PR TITLE
correct clean_mixture() for limiting cases with f=1 (all insects)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # bioRad 0.11.0.9000 (development version)
-* corrections in `clean_mixture()` documentation (#752)
+
+* Bugfix correcting removals of pure insect cases in `clean_mixture()` (#753).
 
 * `eta_to_dbz()` now accepts NA or NaN input reflectivity values (#741).
 

--- a/R/clean_mixture.R
+++ b/R/clean_mixture.R
@@ -172,11 +172,13 @@ clean_mixture.default <- function(x, slow = 1, fast = 8, drop_slow_component = T
   if(drop_slow_component){
     # fast component airspeed, typically birds:
     eta_corr[idx]=((1-f)*x)[idx]
+    eta_corr[idx_f_one]=0
     air_u[idx]=(((u-u_wind)-(slow/wind_speed)*u_wind*f)/(1-f))[idx]
     air_v[idx]=(((v-v_wind)-(slow/wind_speed)*v_wind*f)/(1-f))[idx]
   } else{
     # slow component airspeed, typically insects:
     eta_corr[idx]=(f*x)[idx]
+    eta_corr[idx_f_zero]=0
     air_u[idx]=slow*cos(wind_direction)[idx]
     air_v[idx]=slow*sin(wind_direction)[idx]
   }


### PR DESCRIPTION
Bugfix for missing removals of full insect cases (limiting case with f=1), whose reflectivity values were erroneously not removed when `drop_slow_component=TRUE`. Similarly, full bird cases with f=0 where erroneously not removed when `drop_slow_component=FALSE`.