### PR TITLE
validate_vpts() should allow for NA in integer type fields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bioRad 0.11.0.9000 (development version)
 
+* Bugfix correcting uninformative error message when integer value columns in vpts data.frame contain `NA` values (#755).
+
 * Bugfix correcting removals of pure insect cases in `clean_mixture()` (#753).
 
 * `eta_to_dbz()` now accepts NA or NaN input reflectivity values (#741).

--- a/R/validate_vpts.R
+++ b/R/validate_vpts.R
@@ -46,12 +46,15 @@ validate_vpts <- function(df) {
 
             field_data <- df[[field]]
             # Validate type
-            type_valid <- switch(as.character(field_schema$type), string = is.character(field_data),
-                number = is.numeric(field_data), integer = is.integer(field_data) ||
-                  (is.numeric(field_data) && all(field_data == floor(field_data))),
-                datetime = inherits(field_data, "POSIXct") || inherits(field_data,
-                  "POSIXt"), boolean = is.logical(field_data), stop("Unsupported type specified in schema for field: ",
-                  field))
+            type_valid <- switch(as.character(field_schema$type),
+                                 string = is.character(field_data),
+                                 number = is.numeric(field_data),
+                                 integer = is.integer(field_data) || (is.numeric(field_data) && all(field_data == floor(field_data), na.rm=TRUE)),
+                                 datetime = inherits(field_data, "POSIXct") || inherits(field_data, "POSIXt"),
+                                 boolean = is.logical(field_data),
+                                 stop("Unsupported type specified in schema for field: ",field)
+                                 )
+
             if (!type_valid) {
                 issues <- c(issues, glue::glue("Type validation failed for {field}"))
             }


### PR DESCRIPTION
`validate_vpts()` gives an uninformative error message
```
Error in if (!type_valid) { : missing value where TRUE/FALSE needed
```
whenever integer type profile fields (like `n`, `n_dbz`, etc) contain an NA or NaN value. Default vol2bird output never returns NA or NaN, but users could add NA values potentially, and a vpts data.frame shouldn't be rejected in that case.