### PR TITLE
add alt_min to filter_precip (fix #754)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # bioRad 0.11.0.9000 (development version)
 
+* New additional arguments `alt_min` and `filter_all_heights` in `filter_precip()` for precip filtering at high altitudes only (#755).
+
+* Bugfix for `filter_precip()` not being applied to `vp` objects (#755).
+
 * Bugfix correcting uninformative error message when integer value columns in vpts data.frame contain `NA` values (#755).
 
 * Bugfix correcting removals of pure insect cases in `clean_mixture()` (#753).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bioRad 0.11.0.9000 (development version)
 
+* Bugfix for `as.vpts()` fixing uninformative error message in the case of NA values in the `source_file` column of a vpts data.frame (#759).
+
 * New additional arguments `alt_min` and `filter_all_heights` in `filter_precip()` for precip filtering at high altitudes only (#755).
 
 * Bugfix for `filter_precip()` not being applied to `vp` objects (#755).

--- a/R/filter_precip.R
+++ b/R/filter_precip.R
@@ -12,6 +12,10 @@
 #' `DBZH` > `dbz` at which the filter is triggered in m.
 #' @param alt_max Maximum altitude above ground level to consider in m.
 #' @param drop When `TRUE` the profile is removed from the
+#' @param alt_min Minimum altitude above ground level to consider in m.
+#' @param filter_all_heights When `TRUE` and a precipitation event is detected,
+#' the entire altitude profile will be filtered. When `FALSE`, only the altitude
+#' layers between `alt_min` and `alt_max` will be filtered.
 #' @return A `vpts` object or a `vp` object, depending on input `x`.
 #'
 #' @export
@@ -69,37 +73,52 @@
 #' plot(regularize_vpts(example_vpts), quantity='dens')
 #' # filter can also be applied to single vp objects:
 #' filter_precip(example_vp)
-filter_precip <- function(x, dbz=ifelse(x$attributes$how$wavelength<7 || is.null(x$attributes$how$wavelength),7,20), range=2500, alt_max=3000, drop=FALSE){
+filter_precip <- function(x, dbz=ifelse(x$attributes$how$wavelength<7 || is.null(x$attributes$how$wavelength),7,20), range=2500, alt_max=3000, drop=FALSE, alt_min=0, filter_all_heights=TRUE){
   assertthat::assert_that(is.vp(x) | is.vpts(x))
   assertthat::assert_that(assertthat::is.number(dbz))
   assertthat::assert_that(assertthat::is.number(range))
   assertthat::assert_that(assertthat::is.number(alt_max))
   assertthat::assert_that(alt_max>0)
-  assertthat::assert_that(assertthat::is.flag(drop))
+  assertthat::assert_that(alt_min>=0)
+  assertthat::assert_that(alt_min<alt_max)
+  assertthat::assert_that(alt_max-alt_min>=range)
+  assertthat::is.flag(drop)
+  assertthat::is.flag(filter_all_heights)
   assertthat::assert_that(range<=alt_max)
   assertthat::assert_that(!(drop & is.vp(x)), msg='parameter `drop` should be `TRUE` for objects of class `vp`')
   if(dbz<7) warning("dbz value too low for typical precipitation")
   height_index_max <- ((x$attributes$where$height + alt_max) %/% x$attributes$where$interval)
   height_index_max <- min(x$attributes$where$levels,height_index_max)
+  height_index_min <- ((x$attributes$where$height + alt_min) %/% x$attributes$where$interval)
+  height_index_min <- min(x$attributes$where$levels,height_index_min)
+
   if(is.vpts(x)){
-    height_range <- colSums(x$data$DBZH[1:height_index_max,]>dbz,na.rm=T)*x$attributes$where$interval
+    height_range <- colSums(x$data$DBZH[height_index_min:height_index_max,]>dbz,na.rm=T)*x$attributes$where$interval
   } else{
-    height_range <- sum(x$data$DBZH[1:height_index_max]>dbz,na.rm=T)*x$attributes$where$interval
+    height_range <- sum(x$data$DBZH[height_index_min:height_index_max]>dbz,na.rm=T)*x$attributes$where$interval
   }
 
   index <- which(height_range > range)
+
+  # determine which altitude bins to update
+  if(filter_all_heights){
+    index_heights = 1:x$attributes$where$levels
+  } else {
+    index_heights = height_index_min:height_index_max
+  }
+
   if(length(index)==0) return(x)
   # if remove, drop the profiles
   if(drop) return(x[-index])
   # otherwise set the density field to zero, but keep the profile
   if(is.vpts(x)){
-    x$data$dens[,index] <- 0
-    x$data$eta[,index] <- 0
-    x$data$dbz[,index] <- -Inf
+    x$data$dens[index_heights,index] <- 0
+    x$data$eta[index_heights,index] <- 0
+    x$data$dbz[index_heights,index] <- -Inf
   } else{
-    x$data$dens[index] <- 0
-    x$data$eta[index] <- 0
-    x$data$dbz[index] <- -Inf
+    x$data$dens[index_heights] <- 0
+    x$data$eta[index_heights] <- 0
+    x$data$dbz[index_heights] <- -Inf
   }
 
   x

--- a/R/validate_vpts.R
+++ b/R/validate_vpts.R
@@ -76,7 +76,7 @@ validate_vpts <- function(df) {
                   field_schema$constraints$maximum, na.rm = TRUE)) {
                   return(glue::glue("Maximum value constraint violated for {field}"))
                 c}
-                if (!is.na(field_schema$constraints$pattern) && any(!stringr::str_detect(field_data, field_schema$constraints$pattern))) {
+                if (!is.na(field_schema$constraints$pattern) && any(!stringr::str_detect(field_data, field_schema$constraints$pattern), na.rm = TRUE)) {
                   return(glue::glue("Pattern constraint violated for {field}"))
                 }
             }

--- a/R/validate_vpts.R
+++ b/R/validate_vpts.R
@@ -76,8 +76,7 @@ validate_vpts <- function(df) {
                   field_schema$constraints$maximum, na.rm = TRUE)) {
                   return(glue::glue("Maximum value constraint violated for {field}"))
                 c}
-                if (!is.na(field_schema$constraints$pattern) && any(!stringr::str_detect(field_schema$constraints$pattern,
-                  field_data))) {
+                if (!is.na(field_schema$constraints$pattern) && any(!stringr::str_detect(field_data, field_schema$constraints$pattern))) {
                   return(glue::glue("Pattern constraint violated for {field}"))
                 }
             }

--- a/man/filter_precip.Rd
+++ b/man/filter_precip.Rd
@@ -10,7 +10,9 @@ filter_precip(
     7, 20),
   range = 2500,
   alt_max = 3000,
-  drop = FALSE
+  drop = FALSE,
+  alt_min = 0,
+  filter_all_heights = TRUE
 )
 }
 \arguments{
@@ -25,6 +27,12 @@ Defaults to 7 dBZ for C-band radars and 20 dBZ for S-band radars.}
 \item{alt_max}{Maximum altitude above ground level to consider in m.}
 
 \item{drop}{When \code{TRUE} the profile is removed from the}
+
+\item{alt_min}{Minimum altitude above ground level to consider in m.}
+
+\item{filter_all_heights}{When \code{TRUE} and a precipitation event is detected,
+the entire altitude profile will be filtered. When \code{FALSE}, only the altitude
+layers between \code{alt_min} and \code{alt_max} will be filtered.}
 }
 \value{
 A \code{vpts} object or a \code{vp} object, depending on input \code{x}.

--- a/tests/testthat/test-filter_precip.R
+++ b/tests/testthat/test-filter_precip.R
@@ -1,0 +1,3 @@
+test_that("filter_precip() - skipping, FIXME needs to be implemented", {
+
+})


### PR DESCRIPTION
fixes issue #754, by adding
- `alt_min` argument to specify minimum altitude
- `filter_all_heights` logical argument, to determine whether to filter only in the altitude range selected or not

Also fixes a bug in applying this function to `vp` objects, which was applied only to the first altitude bin.

This PR also includes a fix for unrelated issue #759 