### PR TITLE
allow inclusion of zero nyquist velocity sweeps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bioRad 0.11.0.9000 (development version)
 
+* Changed lower bound of allowed values for `nyquist_min` argument of `calculate_vp()` to zero (#761).
+
 * Bugfix for `as.vpts()` fixing uninformative error message in the case of NA values in the `source_file` column of a vpts data.frame (#759).
 
 * New additional arguments `alt_min` and `filter_all_heights` in `filter_precip()` for precip filtering at high altitudes only (#755).

--- a/R/calculate_vp.R
+++ b/R/calculate_vp.R
@@ -325,7 +325,7 @@ calculate_vp <- function(file, vpfile = "", pvolfile_out = "",
   )
   assertthat::assert_that(assertthat::is.number(nyquist_min))
   assertthat::assert_that(
-    nyquist_min > 0,
+    nyquist_min >= 0,
     msg = "`nyquist_min` must be a positive number."
   )
   assertthat::assert_that(


### PR DESCRIPTION
`nyquist_min` argument in `calculate_vp()` now allows value of zero