### PR TITLE
Remove vdiffr from Suggest

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,7 +66,6 @@ Suggests:
     rmarkdown,
     rosm,
     testthat (>= 3.0.0),
-    vdiffr,
     vol2birdR (>= 1.3.0),
     withr
 LazyData: true


### PR DESCRIPTION
Plot testing with vdiffr was disabled in https://github.com/adokter/bioRad/commit/9d32c093f50c4eaef1ed6b2e768a11e790cf6838 and has since been entirely removed. So the suggested dependency can also be removed.

Related #491 can be closes as well.